### PR TITLE
Fix order of matches in MatchingUtils (and therefore Link implementations)

### DIFF
--- a/tutor/src/main/java/org/tudalgo/algoutils/tutor/general/match/MatchingUtils.java
+++ b/tutor/src/main/java/org/tudalgo/algoutils/tutor/general/match/MatchingUtils.java
@@ -3,6 +3,8 @@ package org.tudalgo.algoutils.tutor.general.match;
 import java.util.Collection;
 import java.util.List;
 
+import static java.util.Comparator.reverseOrder;
+
 public class MatchingUtils {
 
     /**
@@ -14,7 +16,7 @@ public class MatchingUtils {
      * @return the list of matched objects
      */
     public static <T> List<T> matches(Collection<T> objects, Matcher<? super T> matcher) {
-        return objects.stream().map(matcher::match).filter(Match::matched).sorted().map(Match::object).toList();
+        return objects.stream().map(matcher::match).filter(Match::matched).sorted(reverseOrder()).map(Match::object).toList();
     }
 
     /**


### PR DESCRIPTION
Matches returned by MatchingUtils#matches(Collection,Matcher) were sorted in _ascending_ order - in contrast to the specification. Therefore matches returned by methods in Basic*Link implementations returned their matches in wrong order.

This problem is now solved.