### PR TITLE
Fix implementation of Comparable in Match

### DIFF
--- a/tutor/src/main/java/org/tudalgo/algoutils/tutor/general/match/Match.java
+++ b/tutor/src/main/java/org/tudalgo/algoutils/tutor/general/match/Match.java
@@ -56,7 +56,7 @@ public interface Match<T> extends Comparable<Match<T>> {
         if (matched() == other.matched()) {
             return 0;
         }
-        return matched() ? -1 : 1;
+        return matched() ? 1 : -1;
     }
 
     /**


### PR DESCRIPTION
The order of numbers returned by compareTo was wrong.

This problem has been solved.