### PR TITLE
Student Test Methods

### DIFF
--- a/student/src/main/java/org/tudalgo/algoutils/student/test/StudentTest.java
+++ b/student/src/main/java/org/tudalgo/algoutils/student/test/StudentTest.java
@@ -1,0 +1,57 @@
+package org.tudalgo.algoutils.student.test;
+
+import java.util.function.Predicate;
+
+/**
+ * A generic test used by students to test their solutions.
+ *
+ * @param <T> The type of the object to test.
+ */
+public class StudentTest<T> {
+    /**
+     * The {@link Predicate} used to test the object.
+     */
+    protected Predicate<T> predicate;
+    /**
+     * The {@link StudentTestResultMessageProvider} used to generate the message for the result.
+     */
+    protected StudentTestResultMessageProvider<T> messageProvider;
+
+    /**
+     * Creates a new {@link StudentTest} with the given {@code predicate} and {@code messageProvider}.
+     *
+     * @param predicate       The {@link Predicate} used to test the object.
+     * @param messageProvider The {@link StudentTestResultMessageProvider} used to generate the message for the result.
+     */
+    public StudentTest(Predicate<T> predicate, StudentTestResultMessageProvider<T> messageProvider) {
+        this.predicate = predicate;
+        this.messageProvider = messageProvider;
+    }
+
+    /**
+     * Tests the given {@code toTest} object with the {@link #predicate} and returns a {@link StudentTestResult} with
+     * the result.
+     *
+     * @param toTest The object to test.
+     * @return The generated {@link StudentTestResult}.
+     */
+    public StudentTestResult<T> test(T toTest) {
+        final var resultBuilder = StudentTestResult
+            .builder(this)
+            .setToTest(toTest);
+        try {
+            if (predicate.test(toTest)) {
+                resultBuilder.setState(StudentTestState.PASSED);
+            } else {
+                resultBuilder.setState(StudentTestState.FAILED_BY_ASSERTION);
+                resultBuilder.setThrowable(new AssertionError());
+            }
+        } catch (Throwable throwable) {
+            resultBuilder
+                .setState(StudentTestState.FAILED_WITH_EXCEPTION)
+                .setThrowable(throwable);
+        }
+        resultBuilder.setMessage(messageProvider.getMessage(resultBuilder.build()));
+        return resultBuilder.build();
+    }
+}

--- a/student/src/main/java/org/tudalgo/algoutils/student/test/StudentTestResult.java
+++ b/student/src/main/java/org/tudalgo/algoutils/student/test/StudentTestResult.java
@@ -1,0 +1,176 @@
+package org.tudalgo.algoutils.student.test;
+
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+/**
+ * The result of a {@link StudentTest}.
+ *
+ * @param state     the {@linkplain StudentTestState state} of the test
+ * @param toTest    the object that was tested
+ * @param throwable the {@link Throwable} that was thrown during the test
+ * @param message   the message of the result or {@code null} if no message was set
+ * @param test      the {@link StudentTest} that generated this result
+ * @param <T>       the type of the object that was tested
+ */
+public record StudentTestResult<T>(
+    StudentTestState state,
+    T toTest,
+    Throwable throwable,
+    String message,
+    StudentTest<T> test
+) {
+
+    /**
+     * Returns whether the test was successful.
+     *
+     * @return {@code true} if the test was successful, {@code false} otherwise
+     */
+
+    public boolean hasPassed() {
+        return state == StudentTestState.PASSED;
+    }
+
+    /**
+     * Returns whether the test has failed.
+     *
+     * @return {@code true} if the test has failed, {@code false} otherwise
+     */
+    public boolean hasFailed() {
+        return state == StudentTestState.FAILED_BY_ASSERTION || state == StudentTestState.FAILED_WITH_EXCEPTION;
+    }
+
+    /**
+     * Returns whether {@link #toTest} matches the predicate of the {@link #test}.
+     *
+     * @return {@code true} if {@link #toTest} matches the predicate of the {@link #test}, {@code false} otherwise
+     */
+    public boolean hasFailedByAssertion() {
+        return state == StudentTestState.FAILED_BY_ASSERTION;
+    }
+
+    /**
+     * Returns whether there was an exception during the test execution.
+     *
+     * @return {@code true} if there was an exception during the test execution, {@code false} otherwise
+     */
+    public boolean hasFailedWithException() {
+        return state == StudentTestState.FAILED_WITH_EXCEPTION;
+    }
+
+    /**
+     * A builder for {@link StudentTestResult}s.
+     *
+     * @param <T> the type of the object that was tested
+     */
+    public static class Builder<T> {
+        /**
+         * The {@linkplain StudentTestState state} of the test.
+         */
+        private StudentTestState state = StudentTestState.NOT_STARTED;
+        /**
+         * The object that was tested.
+         */
+        private T toTest;
+        /**
+         * The {@link Throwable} that was thrown during the test.
+         */
+        private Throwable throwable;
+        /**
+         * The message of the result or {@code null} if no message was set.
+         */
+        private String message;
+        /**
+         * The {@link StudentTest} that generated the result.
+         */
+        private StudentTest<T> test;
+
+        /**
+         * Creates a new {@link Builder} for the given {@code test}.
+         *
+         * @param test the {@link StudentTest} that generated the result
+         */
+        private Builder(StudentTest<T> test) {
+            this.test = test;
+        }
+
+        /**
+         * Sets the {@linkplain StudentTestState state} of the test.
+         *
+         * @param state the {@linkplain StudentTestState state} of the test
+         * @return this {@link Builder}
+         */
+        public Builder<T> setState(StudentTestState state) {
+            this.state = state;
+            return this;
+        }
+
+        /**
+         * Sets the object that was tested.
+         *
+         * @param toTest the object that was tested
+         * @return this {@link Builder}
+         */
+        public Builder<T> setToTest(T toTest) {
+            this.toTest = toTest;
+            return this;
+        }
+
+        /**
+         * Sets the {@link Throwable} that was thrown during the test.
+         *
+         * @param throwable the {@link Throwable} that was thrown during the test
+         * @return this {@link Builder}
+         */
+        public Builder<T> setThrowable(Throwable throwable) {
+            this.throwable = throwable;
+            return this;
+        }
+
+        /**
+         * Sets the message of the result.
+         *
+         * @param message the message of the result
+         * @return this {@link Builder}
+         */
+        public Builder<T> setMessage(String message) {
+            this.message = message;
+            return this;
+        }
+
+        /**
+         * Builds the {@link StudentTestResult}.
+         *
+         * @return the {@link StudentTestResult}
+         */
+        public StudentTestResult<T> build() {
+            return new StudentTestResult<>(state, toTest, throwable, message, test);
+        }
+    }
+
+    /**
+     * Creates a new {@link Builder} for the given {@code test}.
+     *
+     * @param test the {@link StudentTest} that generated the result
+     * @param <T>  the type of the object that was tested
+     * @return the {@link Builder}
+     */
+    public static <T> Builder<T> builder(StudentTest<T> test) {
+        return new Builder<>(test);
+    }
+
+    /**
+     * Creates a new {@link Builder} for the given {@link StudentTestResult} and copies all values from it.
+     *
+     * @param result the {@link StudentTestResult} to copy
+     * @param <T>    the type of the object that was tested
+     * @return the {@link Builder}
+     */
+    public static <T> Builder<T> builder(StudentTestResult<T> result) {
+        return new Builder<>(result.test)
+            .setState(result.state)
+            .setToTest(result.toTest)
+            .setThrowable(result.throwable)
+            .setMessage(result.message);
+    }
+}

--- a/student/src/main/java/org/tudalgo/algoutils/student/test/StudentTestResult.java
+++ b/student/src/main/java/org/tudalgo/algoutils/student/test/StudentTestResult.java
@@ -1,8 +1,5 @@
 package org.tudalgo.algoutils.student.test;
 
-import java.util.function.Predicate;
-import java.util.function.Supplier;
-
 /**
  * The result of a {@link StudentTest}.
  *
@@ -83,7 +80,7 @@ public record StudentTestResult<T>(
         /**
          * The {@link StudentTest} that generated the result.
          */
-        private StudentTest<T> test;
+        private final StudentTest<T> test;
 
         /**
          * Creates a new {@link Builder} for the given {@code test}.

--- a/student/src/main/java/org/tudalgo/algoutils/student/test/StudentTestResultMessageProvider.java
+++ b/student/src/main/java/org/tudalgo/algoutils/student/test/StudentTestResultMessageProvider.java
@@ -1,0 +1,17 @@
+package org.tudalgo.algoutils.student.test;
+
+/**
+ * A functional interface used to generate the message for a {@link StudentTestResult}.
+ *
+ * @param <T> The type of the object that was tested.
+ */
+@FunctionalInterface
+public interface StudentTestResultMessageProvider<T> {
+    /**
+     * Generates the message for the given {@code result}.
+     *
+     * @param result The {@link StudentTestResult} to generate the message for.
+     * @return The generated message.
+     */
+    String getMessage(StudentTestResult<T> result);
+}

--- a/student/src/main/java/org/tudalgo/algoutils/student/test/StudentTestState.java
+++ b/student/src/main/java/org/tudalgo/algoutils/student/test/StudentTestState.java
@@ -1,0 +1,50 @@
+package org.tudalgo.algoutils.student.test;
+
+/**
+ * The state of a {@link StudentTest}.
+ */
+enum StudentTestState {
+    /**
+     * The test has not been started yet.
+     */
+    NOT_STARTED,
+    /**
+     * The test has passed successfully.
+     */
+    PASSED,
+    /**
+     * The test has failed because the assertion failed.
+     */
+    FAILED_BY_ASSERTION,
+    /**
+     * The test has failed because an exception was thrown.
+     */
+    FAILED_WITH_EXCEPTION;
+
+    /**
+     * Returns whether the test has been run.
+     *
+     * @return {@code true} if the test has been run, {@code false} otherwise
+     */
+    public boolean finished() {
+        return this != NOT_STARTED;
+    }
+
+    /**
+     * Returns whether the test has passed.
+     *
+     * @return {@code true} if the test has passed, {@code false} otherwise
+     */
+    public boolean hasPassed() {
+        return this == PASSED;
+    }
+
+    /**
+     * Returns whether the test has failed.
+     *
+     * @return {@code true} if the test has failed, {@code false} otherwise
+     */
+    public boolean hasFailed() {
+        return this == FAILED_BY_ASSERTION || this == FAILED_WITH_EXCEPTION;
+    }
+}

--- a/student/src/main/java/org/tudalgo/algoutils/student/test/StudentTestUtils.java
+++ b/student/src/main/java/org/tudalgo/algoutils/student/test/StudentTestUtils.java
@@ -59,16 +59,16 @@ public class StudentTestUtils {
      *              return a > b ? a : b;
      *            }
      *            public static void main(String[] args) {
-     *              check_expect(3, max(2, 3));
-     *              check_expect(3, max(3, 2));
-     *              check_expect(3, max(3, 3));
+     *              testEquals(3, max(2, 3));
+     *              testEquals(3, max(3, 2));
+     *              testEquals(3, max(3, 3));
      *            }
      *      }</pre>
      *
      * @param expected the expected value
      * @param actual   the actual value
      */
-    public static void check_expect(Object expected, Object actual) {
+    public static void testEquals(Object expected, Object actual) {
         simpleStudentTest(
             actual,
             a -> a.equals(expected),
@@ -77,7 +77,7 @@ public class StudentTestUtils {
     }
 
     /**
-     * Checks that the given {@code actual} number is in the given {@code range} (inclusive).
+     * Checks that the given {@code actual} value is in the range {@code [min, max]}. The range is inclusive.
      * If the value is not in the range, an error message is printed to {@link #S_TEST_ERR}.
      *
      * <p>This method is intended to be used in the context of a test case from the student.
@@ -85,10 +85,10 @@ public class StudentTestUtils {
      * <p>Example:
      * <pre>{@code
      *           public static void main(String[] args) {
-     *               check_range(0, 10, 5);
-     *               check_range(0, 10, 0);
-     *               check_range(0, 10, 10);
-     *               check_range(0, 10, -1); // will print an error message
+     *               testWithinRange(0, 10, 5);
+     *               testWithinRange(0, 10, 0);
+     *               testWithinRange(0, 10, 10);
+     *               testWithinRange(0, 10, -1); // will print an error message
      *           }
      *     }</pre>
      *
@@ -96,12 +96,36 @@ public class StudentTestUtils {
      * @param max    the maximum value of the range
      * @param actual the actual value
      */
-    public static void check_range(double min, double max, double actual) {
+    public static <T extends Comparable<T>> void testWithinRange(T min, T max, T actual) {
         simpleStudentTest(
             actual,
-            a -> min <= actual && actual <= max,
+            a -> a.compareTo(min) >= 0 && a.compareTo(max) <= 0,
             r -> String.format("Expected: <%s> to be in range <%s, %s>, but was not", actual, min, max)
         );
+    }
+
+    /**
+     * Checks that the given {@code actual} value is in the range {@code [min, max]}. The range is inclusive.
+     * If the value is not in the range, an error message is printed to {@link #S_TEST_ERR}.
+     *
+     * <p>This method is intended to be used in the context of a test case from the student.
+     *
+     * <p>Example:
+     * <pre>{@code
+     *          public static void main(String[] args) {
+     *              testWithinRange(0, 10, 5);
+     *              testWithinRange(0, 10, 0);
+     *              testWithinRange(0, 10, 10);
+     *              testWithinRange(0, 10, -1); // will print an error message
+     *          }
+     *      }</pre>
+     *
+     * @param min    the minimum value of the range
+     * @param max    the maximum value of the range
+     * @param actual the actual value
+     */
+    public static void testWithinRange(double min, double max, double actual) {
+        testWithinRange(Double.valueOf(min), Double.valueOf(max), Double.valueOf(actual));
     }
 
     /**
@@ -116,20 +140,19 @@ public class StudentTestUtils {
         final var failedByAssertion = testResults.stream().filter(StudentTestResult::hasFailedByAssertion).count();
         final var failedWithException = testResults.stream().filter(StudentTestResult::hasFailedWithException).count();
         final var failed = failedByAssertion + failedWithException;
-        String message = "";
+        final StringBuilder messageBuilder = new StringBuilder();
         if (failed == 0) {
-            message = String.format("All %s test(s) passed!%n", passed);
+            messageBuilder.append(String.format("All %s test(s) passed!%n", passed));
         } else {
-            final StringBuilder sb = new StringBuilder();
-            sb.append(String.format("%s of %s total test(s) passed!%n", passed, testResults.size()));
+            messageBuilder.append(String.format("%s of %s total test(s) passed!%n", passed, testResults.size()));
             if (failedByAssertion > 0) {
-                sb.append(String.format(" %s test(s) were executed, but failed by assertion.%n", failedByAssertion));
+                messageBuilder.append(String.format(" %s test(s) were executed, but failed by assertion.%n", failedByAssertion));
             }
             if (failedWithException > 0) {
-                sb.append(String.format(" %s test(s) threw an exception during execution.%n", failedWithException));
+                messageBuilder.append(String.format(" %s test(s) threw an exception during execution.%n", failedWithException));
             }
-            message = sb.toString();
         }
+        final var message = messageBuilder.toString();
         // get length of longest line
         final var longestLine = message.lines().mapToInt(String::length).max().orElse("Test results summary".length());
         // print header

--- a/student/src/main/java/org/tudalgo/algoutils/student/test/StudentTestUtils.java
+++ b/student/src/main/java/org/tudalgo/algoutils/student/test/StudentTestUtils.java
@@ -1,0 +1,143 @@
+package org.tudalgo.algoutils.student.test;
+
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Predicate;
+
+/**
+ * Utility class for tests written by students.
+ */
+public class StudentTestUtils {
+    /**
+     * The {@link PrintStream} to use for test output.
+     */
+    public static PrintStream S_TEST_OUT = System.out;
+    /**
+     * The {@link PrintStream} to use for test error output.
+     */
+    public static PrintStream S_TEST_ERR = System.err;
+
+    /**
+     * The list of all {@linkplain StudentTestResult test results} created by the student tests.
+     */
+
+    public static List<StudentTestResult<?>> testResults = new ArrayList<>();
+
+    /**
+     * Utility method to create a {@link StudentTest} with the given {@code predicate} and {@code messageProvider} and
+     * apply it to the given {@code toTest} value. The result is added to {@link #testResults}.
+     *
+     * @param toTest          the value to test
+     * @param predicate       the predicate to test the value with
+     * @param messageProvider the message provider to create the message for the result
+     * @param <T>             the type of the value to test
+     */
+    private static <T> void simpleStudentTest(
+        T toTest,
+        Predicate<T> predicate,
+        StudentTestResultMessageProvider<T> messageProvider
+    ) {
+        var test = new StudentTest<>(predicate, messageProvider);
+        final var result = test.test(toTest);
+        testResults.add(result);
+        if (result.hasFailed()) {
+            S_TEST_ERR.println(result.message());
+            result.throwable().printStackTrace(S_TEST_ERR);
+        }
+    }
+
+    /**
+     * Checks that the given {@code expected} value is equal to the given {@code actual} value.
+     * If the values are not equal, an error message is printed to {@link #S_TEST_ERR}.
+     *
+     * <p>This method is intended to be used in the context of a test case from the student.
+     *
+     * <p>Example:
+     * <pre>{@code
+     *            public static int max(int a, int b) {
+     *              return a > b ? a : b;
+     *            }
+     *            public static void main(String[] args) {
+     *              check_expect(3, max(2, 3));
+     *              check_expect(3, max(3, 2));
+     *              check_expect(3, max(3, 3));
+     *            }
+     *      }</pre>
+     *
+     * @param expected the expected value
+     * @param actual   the actual value
+     */
+    public static void check_expect(Object expected, Object actual) {
+        simpleStudentTest(
+            actual,
+            a -> a.equals(expected),
+            r -> String.format("Expected: <%s>, but was: <%s>", expected, r.toTest())
+        );
+    }
+
+    /**
+     * Checks that the given {@code actual} number is in the given {@code range} (inclusive).
+     * If the value is not in the range, an error message is printed to {@link #S_TEST_ERR}.
+     *
+     * <p>This method is intended to be used in the context of a test case from the student.
+     *
+     * <p>Example:
+     * <pre>{@code
+     *           public static void main(String[] args) {
+     *               check_range(0, 10, 5);
+     *               check_range(0, 10, 0);
+     *               check_range(0, 10, 10);
+     *               check_range(0, 10, -1); // will print an error message
+     *           }
+     *     }</pre>
+     *
+     * @param min    the minimum value of the range
+     * @param max    the maximum value of the range
+     * @param actual the actual value
+     */
+    public static void check_range(double min, double max, double actual) {
+        simpleStudentTest(
+            actual,
+            a -> min <= actual && actual <= max,
+            r -> String.format("Expected: <%s> to be in range <%s, %s>, but was not", actual, min, max)
+        );
+    }
+
+    /**
+     * Prints a summary of the test results to {@link #S_TEST_OUT}.
+     * The summary contains the number of passed and failed tests.
+     *
+     * <p>This method is intended to be used in the context of a test case from the student.
+     * Ideally, it is called at the end of the {@code main} method.
+     */
+    public static void printTestResults() {
+        final var passed = testResults.stream().filter(StudentTestResult::hasPassed).count();
+        final var failedByAssertion = testResults.stream().filter(StudentTestResult::hasFailedByAssertion).count();
+        final var failedWithException = testResults.stream().filter(StudentTestResult::hasFailedWithException).count();
+        final var failed = failedByAssertion + failedWithException;
+        String message = "";
+        if (failed == 0) {
+            message = String.format("All %s test(s) passed!%n", passed);
+        } else {
+            final StringBuilder sb = new StringBuilder();
+            sb.append(String.format("%s of %s total test(s) passed!%n", passed, testResults.size()));
+            if (failedByAssertion > 0) {
+                sb.append(String.format(" %s test(s) were executed, but failed by assertion.%n", failedByAssertion));
+            }
+            if (failedWithException > 0) {
+                sb.append(String.format(" %s test(s) threw an exception during execution.%n", failedWithException));
+            }
+            message = sb.toString();
+        }
+        // get length of longest line
+        final var longestLine = message.lines().mapToInt(String::length).max().orElse("Test results summary".length());
+        // print header
+        S_TEST_OUT.println("=".repeat(longestLine));
+        S_TEST_OUT.println("Test results summary");
+        S_TEST_OUT.println("-".repeat(longestLine));
+        S_TEST_OUT.print(message);
+        // print footer
+        S_TEST_OUT.println("=".repeat(longestLine));
+    }
+}


### PR DESCRIPTION
Fixes #83.

Example usage:
```java
public static void main(final String... args) {
    testEquals(2, 2);
    testEquals(2, 2.2);
    testWithinRange(5, 10, 7);
    testWithinRange(5, 10.2, 12d);

    // print test summary
    printTestResults();
}
```
This will produce the following output:
```
Expected: <2>, but was: <2.2>
java.lang.AssertionError
	at org.tudalgo.algoutils.student.test.StudentTest.test(StudentTest.java:47)
	at org.tudalgo.algoutils.student.test.StudentTestUtils.simpleStudentTest(StudentTestUtils.java:42)
	at org.tudalgo.algoutils.student.test.StudentTestUtils.testEquals(StudentTestUtils.java:72)
	at h01.Main.main(Main.java:17)
Expected: <12.0> to be in range <5.0, 10.2>, but was not
java.lang.AssertionError
	at org.tudalgo.algoutils.student.test.StudentTest.test(StudentTest.java:47)
	at org.tudalgo.algoutils.student.test.StudentTestUtils.simpleStudentTest(StudentTestUtils.java:42)
	at org.tudalgo.algoutils.student.test.StudentTestUtils.testWithinRange(StudentTestUtils.java:100)
	at org.tudalgo.algoutils.student.test.StudentTestUtils.testWithinRange(StudentTestUtils.java:128)
	at h01.Main.main(Main.java:19)
==================================================
Test results summary
--------------------------------------------------
2 of 4 total test(s) passed!
 2 test(s) were executed, but failed by assertion.
==================================================
```
Note that the failed tests will print to system.err while the test summary prints to system.out. this might lead to inconsistencies with the print order. This might need to be changed for that reason.