### PR TITLE
Improve method getCtElement in classes BasicTypeLink and BasicMethodLink

### DIFF
--- a/tutor/src/main/java/org/tudalgo/algoutils/tutor/general/reflections/BasicMethodLink.java
+++ b/tutor/src/main/java/org/tudalgo/algoutils/tutor/general/reflections/BasicMethodLink.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Map;
 
 import static java.util.Arrays.stream;
+import static org.tudalgo.algoutils.tutor.general.Utils.listOfCtParametersToTypeLinks;
 
 /**
  * A basic implementation of a {@link MethodLink method link}.

--- a/tutor/src/main/java/org/tudalgo/algoutils/tutor/general/reflections/BasicMethodLink.java
+++ b/tutor/src/main/java/org/tudalgo/algoutils/tutor/general/reflections/BasicMethodLink.java
@@ -96,12 +96,17 @@ public class BasicMethodLink extends BasicLink implements MethodLink, WithCtElem
         if (parentElement == null) {
             return null;
         }
-        element = (CtMethod<?>) parentElement.getDirectChildren().stream()
-            .filter(e ->
-                e instanceof CtMethod<?> m
-                    && reflection().getName().equals(m.getSimpleName())
-                    && reflection().getReturnType().getSimpleName().equals(m.getType().getSimpleName())
-            ).findFirst().orElse(null);
+        element = parentElement.getDirectChildren().stream()
+            // filter methods
+            .filter(e -> e instanceof CtMethod<?>)
+            // map to methods
+            .map(e -> (CtMethod<?>) e)
+            // filter fitting methods
+            .filter(m -> reflection().getName().equals(m.getSimpleName()))
+            // filter fitting method
+            .filter(m -> listOfCtParametersToTypeLinks(m.getParameters()).equals(parameterTypeLinks))
+            // get fitting method
+            .findFirst().orElse(null);
         return element;
     }
 }

--- a/tutor/src/main/java/org/tudalgo/algoutils/tutor/general/reflections/BasicTypeLink.java
+++ b/tutor/src/main/java/org/tudalgo/algoutils/tutor/general/reflections/BasicTypeLink.java
@@ -115,7 +115,12 @@ public class BasicTypeLink implements TypeLink, WithCtElement {
         if (element != null) {
             return element;
         }
-        element = SpoonUtils.getType(reflection().getName());
+        // retrieve root element if class is nested class
+        var root = reflection();
+        while (root.getDeclaringClass() != null) {
+            root = root.getDeclaringClass();
+        }
+        element = SpoonUtils.getType(root.getName());
         return element;
     }
 


### PR DESCRIPTION
BasicTypeLink: If the type represented by the link was a nested type, the method getCtElement() resulted in an unexpected exception. This problem is fixed by this commit.

BasicMethodLink: If the method represented by the link was overloaded, the method getCtElement() did not always return the correct CtElement. This problem is fixed by this commit.