### PR TITLE
General Improvements for Declaration Tests and other Assertions

### DIFF
--- a/tutor/src/main/java/org/tudalgo/algoutils/tutor/general/SpoonUtils.java
+++ b/tutor/src/main/java/org/tudalgo/algoutils/tutor/general/SpoonUtils.java
@@ -27,12 +27,17 @@ public class SpoonUtils {
     }
 
     /**
+     * <p>Returns a <code>CtElement</code> for the given source code.</p>
+     *
+     * @param ignoredSourceCode  the source code
+     * @param ignoredKind        the kind of the element
+     * @param ignoredNameMatcher the name matcher
      * @deprecated use {@link #getType(String, Class)} instead
      */
     public static <T, U extends CtType<?>> T getCtElementForSourceCode(
-        String ignoredSourceCode,
-        Class<U> ignoredKind,
-        Matcher<Stringifiable> ignoredNameMatcher
+        final String ignoredSourceCode,
+        final Class<U> ignoredKind,
+        final Matcher<Stringifiable> ignoredNameMatcher
     ) {
         throw new UnsupportedOperationException("use getCtModel instead");
     }
@@ -43,7 +48,7 @@ public class SpoonUtils {
      * @param element the element
      * @return the human-readable name
      */
-    public static String getNameOfCtElement(CtElement element) {
+    public static String getNameOfCtElement(final CtElement element) {
         return getNameOfCtElement(element.getClass());
     }
 
@@ -53,9 +58,9 @@ public class SpoonUtils {
      * @param type the element type
      * @return the human-readable name
      */
-    public static String getNameOfCtElement(Class<?> type) {
+    public static String getNameOfCtElement(final Class<?> type) {
         var name = type.getSimpleName();
-        var match = SPOON_NAME_PATTERN.matcher(name);
+        final var match = SPOON_NAME_PATTERN.matcher(name);
         name = match.results().map(m -> m.group(1).toLowerCase()).collect(Collectors.joining(" "));
         return name;
     }
@@ -74,9 +79,9 @@ public class SpoonUtils {
         if (model != null) {
             return model;
         }
-        var launcher = new Launcher();
+        final var launcher = new Launcher();
         //noinspection UnstableApiUsage
-        var cycle = getTestCycle();
+        final var cycle = getTestCycle();
         if (cycle != null) {
             launcher.getEnvironment().setInputClassLoader((ClassLoader) cycle.getClassLoader());
         }
@@ -89,7 +94,7 @@ public class SpoonUtils {
      * @param className the class to get the spoon type for
      * @return the corresponding {@link CtType} in the spoon world for the given class
      */
-    public static CtType<?> getType(String className) {
+    public static CtType<?> getType(final String className) {
         return getType(className, CtType.class);
     }
 
@@ -101,21 +106,24 @@ public class SpoonUtils {
      * @param <T>       the type of the spoon type to return
      * @return the corresponding {@link CtType} in the spoon world for the given class
      */
-    public static <T extends CtType<?>> T getType(String className, Class<T> type) {
-        Launcher launcher = new Launcher();
+    public static <T extends CtType<?>> T getType(final String className, final Class<T> type) {
+        final Launcher launcher = new Launcher();
         launcher.getEnvironment().setComplianceLevel(17);
         launcher.getEnvironment().setIgnoreSyntaxErrors(true);
+        launcher.getEnvironment().setNoClasspath(true);
+        launcher.getEnvironment().setPreserveLineNumbers(true);
+        launcher.getEnvironment().setAutoImports(true);
 
-        String sourceCode = ResourceUtils.getTypeContent(className);
-        VirtualFile file = new VirtualFile(sourceCode, className);
+        final String sourceCode = ResourceUtils.getTypeContent(className);
+        final VirtualFile file = new VirtualFile(sourceCode, className);
 
-        @SuppressWarnings("UnstableApiUsage") TestCycle cycle = getTestCycle();
+        @SuppressWarnings("UnstableApiUsage") final TestCycle cycle = getTestCycle();
         if (cycle != null) {
             launcher.getEnvironment().setInputClassLoader((ClassLoader) cycle.getClassLoader());
         }
 
         launcher.addInputResource(file);
-        CtModel model = launcher.buildModel();
+        final CtModel model = launcher.buildModel();
         return model.getAllTypes().stream()
             .filter(type::isInstance)
             .filter(it -> it.getQualifiedName().equals(className))

--- a/tutor/src/main/java/org/tudalgo/algoutils/tutor/general/assertions/Assertions2.java
+++ b/tutor/src/main/java/org/tudalgo/algoutils/tutor/general/assertions/Assertions2.java
@@ -343,8 +343,24 @@ public final class Assertions2 {
         return Assertions2.<T>testOfThrowableCallBuilder().expected(ExpectedExceptional.instanceOf(expected)).build().run(callable).check(context, preCommentSupplier).actual().behavior();
     }
 
+    /**
+     * <p>Asserts that the given callable does not throw an exception.</p>
+     *
+     * @param callable           the callable to call
+     * @param context            the context of the test
+     * @param preCommentSupplier the supplier of the pre-comment
+     */
     public static void call(Callable callable, Context context, PreCommentSupplier<? super ResultOfCall> preCommentSupplier) {
         Assertions2.testOfCallBuilder().expected(nothing()).build().run(callable).check(context, preCommentSupplier);
+    }
+
+    /**
+     * <p>Asserts that the given callable does not throw an exception.</p>
+     *
+     * @param callable the callable to call
+     */
+    public static void call(Callable callable) {
+        call(callable, emptyContext(), r -> "an unexpected exception was thrown");
     }
 
     /**
@@ -370,8 +386,28 @@ public final class Assertions2 {
             .check(context, preCommentSupplier);
     }
 
+    /**
+     * <p>Asserts that the given callable does not throw an exception and returns the object returned by the callable.</p>
+     *
+     * @param callable           the callable to call
+     * @param context            the context of the test
+     * @param preCommentSupplier the supplier of the pre-comment
+     * @param <T>                the return type of the callable
+     * @return the object returned by the callable
+     */
     public static <T> T callObject(ObjectCallable<T> callable, Context context, PreCommentSupplier<? super ResultOfObject<T>> preCommentSupplier) {
         return Assertions2.<T>testOfObjectBuilder().expected(something()).build().run(callable).check(context, preCommentSupplier).object();
+    }
+
+    /**
+     * <p>Asserts that the given callable does not throw an exception and returns the object returned by the callable.</p>
+     *
+     * @param callable the callable to call
+     * @param <T>      the return type of the callable
+     * @return the object returned by the callable
+     */
+    public static <T> T callObject(ObjectCallable<T> callable) {
+        return callObject(callable, emptyContext(), r -> "an unexpected exception was thrown");
     }
 
     /**

--- a/tutor/src/main/java/org/tudalgo/algoutils/tutor/general/assertions/Assertions2.java
+++ b/tutor/src/main/java/org/tudalgo/algoutils/tutor/general/assertions/Assertions2.java
@@ -77,7 +77,7 @@ import static org.tudalgo.algoutils.tutor.general.assertions.expected.Nothing.no
  *    assertions2.assertEquals(expectedEndY, robot.getY(), context, r -> "The final y coordinate.");
  * }
  * }</pre>
- * In this example the student gets way more information about the test failure than in the Junit5 example while also
+ * <p>In this example the student gets way more information about the test failure than in the Junit5 example while also
  * providing a more readable test method.
  * </p>
  *

--- a/tutor/src/main/java/org/tudalgo/algoutils/tutor/general/assertions/Assertions2.java
+++ b/tutor/src/main/java/org/tudalgo/algoutils/tutor/general/assertions/Assertions2.java
@@ -3,18 +3,31 @@ package org.tudalgo.algoutils.tutor.general.assertions;
 import org.junit.jupiter.api.function.ThrowingSupplier;
 import org.tudalgo.algoutils.tutor.general.Environment;
 import org.tudalgo.algoutils.tutor.general.assertions.actual.Actual;
-import org.tudalgo.algoutils.tutor.general.assertions.basic.*;
+import org.tudalgo.algoutils.tutor.general.assertions.basic.BasicContext;
+import org.tudalgo.algoutils.tutor.general.assertions.basic.BasicFail;
+import org.tudalgo.algoutils.tutor.general.assertions.basic.BasicTestOfCall;
+import org.tudalgo.algoutils.tutor.general.assertions.basic.BasicTestOfExceptionalCall;
+import org.tudalgo.algoutils.tutor.general.assertions.basic.BasicTestOfObject;
 import org.tudalgo.algoutils.tutor.general.assertions.expected.Expected;
 import org.tudalgo.algoutils.tutor.general.assertions.expected.ExpectedExceptional;
 import org.tudalgo.algoutils.tutor.general.assertions.expected.ExpectedObject;
-import org.tudalgo.algoutils.tutor.general.assertions.expected.Nothing;
 import org.tudalgo.algoutils.tutor.general.basic.BasicEnvironment;
 import org.tudalgo.algoutils.tutor.general.callable.Callable;
 import org.tudalgo.algoutils.tutor.general.callable.ObjectCallable;
 
 import java.lang.reflect.InvocationTargetException;
 
-import static org.tudalgo.algoutils.tutor.general.assertions.expected.ExpectedObjects.*;
+import static org.tudalgo.algoutils.tutor.general.assertions.actual.Actual.unexpected;
+import static org.tudalgo.algoutils.tutor.general.assertions.expected.Expected.of;
+import static org.tudalgo.algoutils.tutor.general.assertions.expected.ExpectedObjects.equalTo;
+import static org.tudalgo.algoutils.tutor.general.assertions.expected.ExpectedObjects.equalsFalse;
+import static org.tudalgo.algoutils.tutor.general.assertions.expected.ExpectedObjects.equalsNull;
+import static org.tudalgo.algoutils.tutor.general.assertions.expected.ExpectedObjects.equalsTrue;
+import static org.tudalgo.algoutils.tutor.general.assertions.expected.ExpectedObjects.notEqualsNull;
+import static org.tudalgo.algoutils.tutor.general.assertions.expected.ExpectedObjects.notEqualsTo;
+import static org.tudalgo.algoutils.tutor.general.assertions.expected.ExpectedObjects.notSameAs;
+import static org.tudalgo.algoutils.tutor.general.assertions.expected.ExpectedObjects.sameAs;
+import static org.tudalgo.algoutils.tutor.general.assertions.expected.ExpectedObjects.something;
 import static org.tudalgo.algoutils.tutor.general.assertions.expected.Nothing.nothing;
 
 /**
@@ -22,9 +35,9 @@ import static org.tudalgo.algoutils.tutor.general.assertions.expected.Nothing.no
  * the option to pass along a {@link Context}.</p>
  *
  * <p><b>Note:</b> some methods do not provice a 1:1 mapping to the org.junit.jupiter.api.Assertions class. For example,
- *  * instead of using {@link org.junit.jupiter.api.Assertions#assertDoesNotThrow(ThrowingSupplier)} you should use
- *  * {@link Assertions2#call(Callable, Context, PreCommentSupplier)} or if you need the result of the call you should use
- *  * {@link Assertions2#callObject(ObjectCallable, Context, PreCommentSupplier)}.</p>
+ * * instead of using {@link org.junit.jupiter.api.Assertions#assertDoesNotThrow(ThrowingSupplier)} you should use
+ * * {@link Assertions2#call(Callable, Context, PreCommentSupplier)} or if you need the result of the call you should use
+ * * {@link Assertions2#callObject(ObjectCallable, Context, PreCommentSupplier)}.</p>
  *
  * <p>Here is an example of how to convert Junit5 assertions to Assertions2 assertions:
  *
@@ -453,5 +466,42 @@ public final class Assertions2 {
             }
         }
         return cb.build();
+    }
+
+    /**
+     * <p>Asserts that two arrays are equal.</p>
+     *
+     * @param expected           the expected array
+     * @param actual             the actual array
+     * @param context            the context of the test
+     * @param preCommentSupplier the supplier of the pre-comment
+     */
+    public void assertArrayEquals(
+        Object[] expected,
+        Object[] actual,
+        Context context,
+        PreCommentSupplier<? super ResultOfFail> preCommentSupplier
+    ) {
+        // size check
+        if (expected.length != actual.length) {
+            Assertions2.fail(
+                of(expected.length),
+                unexpected(actual.length),
+                context,
+                r -> preCommentSupplier.getPreComment(r) + "Array lengths differ."
+            );
+        }
+        // element check
+        for (int i = 0; i < expected.length; i++) {
+            if (!expected[i].equals(actual[i])) {
+                final int finalI = i;
+                Assertions2.fail(
+                    of(expected[i]),
+                    unexpected(actual[i]),
+                    context,
+                    r -> preCommentSupplier.getPreComment(r) + "Array elements differ at index " + finalI + "."
+                );
+            }
+        }
     }
 }

--- a/tutor/src/main/java/org/tudalgo/algoutils/tutor/general/assertions/Assertions2.java
+++ b/tutor/src/main/java/org/tudalgo/algoutils/tutor/general/assertions/Assertions2.java
@@ -476,7 +476,7 @@ public final class Assertions2 {
      * @param context            the context of the test
      * @param preCommentSupplier the supplier of the pre-comment
      */
-    public void assertArrayEquals(
+    public static void assertArrayEquals(
         Object[] expected,
         Object[] actual,
         Context context,

--- a/tutor/src/main/java/org/tudalgo/algoutils/tutor/general/assertions/Assertions2.java
+++ b/tutor/src/main/java/org/tudalgo/algoutils/tutor/general/assertions/Assertions2.java
@@ -14,6 +14,7 @@ import org.tudalgo.algoutils.tutor.general.assertions.expected.ExpectedObject;
 import org.tudalgo.algoutils.tutor.general.basic.BasicEnvironment;
 import org.tudalgo.algoutils.tutor.general.callable.Callable;
 import org.tudalgo.algoutils.tutor.general.callable.ObjectCallable;
+import org.tudalgo.algoutils.tutor.general.reflections.MethodLink;
 
 import java.lang.reflect.InvocationTargetException;
 
@@ -345,8 +346,56 @@ public final class Assertions2 {
         Assertions2.testOfCallBuilder().expected(nothing()).build().run(callable).check(context, preCommentSupplier);
     }
 
+    /**
+     * <p>Asserts that the given callable does not throw an exception.</p>
+     *
+     * @param methodLink         the method to call
+     * @param instance           the instance to call the method on
+     * @param context            the context of the test
+     * @param preCommentSupplier the supplier of the pre-comment
+     * @param args               the arguments to pass to the method
+     */
+    public static void call(
+        MethodLink methodLink,
+        Object instance,
+        Context context,
+        PreCommentSupplier<? super ResultOfCall> preCommentSupplier,
+        Object... args
+    ) {
+        Assertions2.testOfCallBuilder()
+            .expected(nothing())
+            .build()
+            .run(() -> methodLink.invoke(instance, args))
+            .check(context, preCommentSupplier);
+    }
+
     public static <T> T callObject(ObjectCallable<T> callable, Context context, PreCommentSupplier<? super ResultOfObject<T>> preCommentSupplier) {
         return Assertions2.<T>testOfObjectBuilder().expected(something()).build().run(callable).check(context, preCommentSupplier).object();
+    }
+
+    /**
+     * <p>Asserts that the given callable does not throw an exception and returns the object returned by the callable.</p>
+     *
+     * @param methodLink         the method to call
+     * @param instance           the instance to call the method on
+     * @param context            the context of the test
+     * @param preCommentSupplier the supplier of the pre-comment
+     * @param args               the arguments to pass to the method
+     * @param <T>                the return type of the method
+     * @return the object returned by the method
+     */
+    public static <T> T callObject(
+        MethodLink methodLink,
+        Object instance,
+        Context context,
+        PreCommentSupplier<? super ResultOfObject<T>> preCommentSupplier,
+        Object... args
+    ) {
+        return Assertions2.<T>testOfObjectBuilder()
+            .expected(something())
+            .build()
+            .run(() -> methodLink.invoke(instance, args))
+            .check(context, preCommentSupplier).object();
     }
 
     /**

--- a/tutor/src/main/java/org/tudalgo/algoutils/tutor/general/assertions/Assertions2.java
+++ b/tutor/src/main/java/org/tudalgo/algoutils/tutor/general/assertions/Assertions2.java
@@ -17,6 +17,7 @@ import org.tudalgo.algoutils.tutor.general.callable.ObjectCallable;
 import org.tudalgo.algoutils.tutor.general.reflections.MethodLink;
 
 import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
 
 import static org.tudalgo.algoutils.tutor.general.assertions.actual.Actual.unexpected;
 import static org.tudalgo.algoutils.tutor.general.assertions.expected.Expected.of;
@@ -518,6 +519,76 @@ public final class Assertions2 {
     }
 
     /**
+     * Asserts that two {@link Iterable}s are equal.
+     *
+     * @param expected           the expected iterable
+     * @param actual             the actual iterable
+     * @param context            the context of the test
+     * @param preCommentSupplier the supplier of the pre-comment
+     * @param iterableName       the name of the iterable
+     */
+    public static void assertIterableEquals(
+        Iterable<?> expected,
+        Iterable<?> actual,
+        Context context,
+        PreCommentSupplier<? super ResultOfFail> preCommentSupplier,
+        String iterableName
+    ) {
+        var expectedIterator = expected.iterator();
+        var actualIterator = actual.iterator();
+        int i = 0;
+        while (expectedIterator.hasNext() && actualIterator.hasNext()) {
+            var expectedElement = expectedIterator.next();
+            var actualElement = actualIterator.next();
+            if (!expectedElement.equals(actualElement)) {
+                final int finalI = i;
+                Assertions2.fail(
+                    of(expectedElement),
+                    unexpected(actualElement),
+                    context,
+                    r -> preCommentSupplier.getPreComment(r) + iterableName + " elements differ at index " + finalI + "."
+                );
+            }
+            i++;
+        }
+        if (expectedIterator.hasNext()) {
+            Assertions2.fail(
+                of("no more elements"),
+                unexpected("end of iterable"),
+                context,
+                r -> preCommentSupplier.getPreComment(r)
+                    + String.format("Expected %s has more elements than actual %s.", iterableName, iterableName)
+            );
+        }
+        if (actualIterator.hasNext()) {
+            Assertions2.fail(
+                of("end of iterable"),
+                unexpected("no more elements"),
+                context,
+                r -> preCommentSupplier.getPreComment(r)
+                    + String.format("Actual %s has more elements than expected %s.", iterableName, iterableName)
+            );
+        }
+    }
+
+    /**
+     * Asserts that two {@link Iterable}s are equal.
+     *
+     * @param expected           the expected iterable
+     * @param actual             the actual iterable
+     * @param context            the context of the test
+     * @param preCommentSupplier the supplier of the pre-comment
+     */
+    public static void assertIterableEquals(
+        Iterable<?> expected,
+        Iterable<?> actual,
+        Context context,
+        PreCommentSupplier<? super ResultOfFail> preCommentSupplier
+    ) {
+        assertIterableEquals(expected, actual, context, preCommentSupplier, "Iterable");
+    }
+
+    /**
      * <p>Asserts that two arrays are equal.</p>
      *
      * @param expected           the expected array
@@ -531,26 +602,12 @@ public final class Assertions2 {
         Context context,
         PreCommentSupplier<? super ResultOfFail> preCommentSupplier
     ) {
-        // size check
-        if (expected.length != actual.length) {
-            Assertions2.fail(
-                of(expected.length),
-                unexpected(actual.length),
-                context,
-                r -> preCommentSupplier.getPreComment(r) + "Array lengths differ."
-            );
-        }
-        // element check
-        for (int i = 0; i < expected.length; i++) {
-            if (!expected[i].equals(actual[i])) {
-                final int finalI = i;
-                Assertions2.fail(
-                    of(expected[i]),
-                    unexpected(actual[i]),
-                    context,
-                    r -> preCommentSupplier.getPreComment(r) + "Array elements differ at index " + finalI + "."
-                );
-            }
-        }
+        assertIterableEquals(
+            Arrays.asList(expected),
+            Arrays.asList(actual),
+            context,
+            preCommentSupplier,
+            "Array"
+        );
     }
 }

--- a/tutor/src/main/java/org/tudalgo/algoutils/tutor/general/assertions/Assertions3.java
+++ b/tutor/src/main/java/org/tudalgo/algoutils/tutor/general/assertions/Assertions3.java
@@ -1,6 +1,30 @@
 package org.tudalgo.algoutils.tutor.general.assertions;
 
+
+import org.tudalgo.algoutils.tutor.general.Environment;
+import org.tudalgo.algoutils.tutor.general.assertions.expected.Expected;
+import org.tudalgo.algoutils.tutor.general.basic.BasicEnvironment;
+import org.tudalgo.algoutils.tutor.general.match.BasicReflectionMatchers;
+import org.tudalgo.algoutils.tutor.general.match.BasicStringMatchers;
+import org.tudalgo.algoutils.tutor.general.match.Matcher;
+import org.tudalgo.algoutils.tutor.general.match.Stringifiable;
+import org.tudalgo.algoutils.tutor.general.reflections.BasicMethodLink;
+import org.tudalgo.algoutils.tutor.general.reflections.BasicTypeLink;
+import org.tudalgo.algoutils.tutor.general.reflections.ConstructorLink;
+import org.tudalgo.algoutils.tutor.general.reflections.EnumConstantLink;
+import org.tudalgo.algoutils.tutor.general.reflections.FieldLink;
+import org.tudalgo.algoutils.tutor.general.reflections.Link;
+import org.tudalgo.algoutils.tutor.general.reflections.MethodLink;
+import org.tudalgo.algoutils.tutor.general.reflections.Modifier;
+import org.tudalgo.algoutils.tutor.general.reflections.PackageLink;
+import org.tudalgo.algoutils.tutor.general.reflections.TypeLink;
+import org.tudalgo.algoutils.tutor.general.reflections.WithModifiers;
+import org.tudalgo.algoutils.tutor.general.reflections.WithTypeList;
+import org.tudalgo.algoutils.tutor.general.stringify.HTML;
+
+import java.lang.reflect.TypeVariable;
 import java.util.List;
+import java.util.function.Predicate;
 
 import static java.lang.String.format;
 import static java.util.Arrays.stream;
@@ -11,16 +35,6 @@ import static org.tudalgo.algoutils.tutor.general.assertions.actual.Actual.unexp
 import static org.tudalgo.algoutils.tutor.general.assertions.expected.Expected.of;
 import static org.tudalgo.algoutils.tutor.general.assertions.expected.Nothing.items;
 import static org.tudalgo.algoutils.tutor.general.stringify.HTML.tt;
-
-import org.tudalgo.algoutils.tutor.general.Environment;
-import org.tudalgo.algoutils.tutor.general.assertions.expected.Expected;
-import org.tudalgo.algoutils.tutor.general.basic.BasicEnvironment;
-import org.tudalgo.algoutils.tutor.general.match.BasicReflectionMatchers;
-import org.tudalgo.algoutils.tutor.general.match.BasicStringMatchers;
-import org.tudalgo.algoutils.tutor.general.match.Matcher;
-import org.tudalgo.algoutils.tutor.general.match.Stringifiable;
-import org.tudalgo.algoutils.tutor.general.reflections.*;
-import org.tudalgo.algoutils.tutor.general.stringify.HTML;
 
 /**
  * <p>The Assertions3 class is a collection of test utils for verifying the declarations of classes, methods, fields,
@@ -88,7 +102,13 @@ public class Assertions3 {
         var typeName = ENVIRONMENT.getStringifier().stringify(link);
         var expectedModifiers = stream(attributes).map(Modifier::keyword).map(HTML::tt).toList();
         var expected = items(expectedModifiers);
-        var actual = items("not", missingModifiers);
+        var actual = items(
+            stream(Modifier.fromInt(link.modifiers()))
+                .map(Modifier::keyword)
+                .map(HTML::tt)
+                .toList() + ". Therefor missing:",
+            missingModifiers
+        );
         return fail(
             expected,
             actual,
@@ -198,6 +218,51 @@ public class Assertions3 {
     }
 
     /**
+     * Asserts that the given {@link Link} has the correct type parameters.
+     *
+     * @param link     the {@link Link} to check
+     * @param matchers the {@link Matcher}s to match the type parameters against
+     */
+    @SafeVarargs
+    public static <T extends Link> void assertCorrectTypeParameters(
+        T link,
+        Matcher<? super TypeVariable<?>>... matchers
+    ) {
+        TypeVariable<?>[] actual;
+        if (link instanceof MethodLink) {
+            actual = ((MethodLink) link).reflection().getTypeParameters();
+        } else if (link instanceof ConstructorLink) {
+            actual = ((ConstructorLink) link).reflection().getTypeParameters();
+        } else if (link instanceof TypeLink) {
+            actual = ((TypeLink) link).reflection().getTypeParameters();
+        } else if (link instanceof FieldLink) {
+            actual = ((FieldLink) link).reflection().getType().getTypeParameters();
+        } else {
+            throw new IllegalArgumentException("link is not a MethodLink, ConstructorLink or TypeLink");
+        }
+        var name = ENVIRONMENT.getStringifier().stringify(link);
+        // length
+        if (matchers.length != actual.length) {
+            fail(
+                Expected.of(List.of(matchers)),
+                unexpected(List.of(actual)),
+                contextBuilder().subject(link).build(),
+                e -> "type parameters are not correct."
+            );
+        }
+        for (int i = 0; i < matchers.length; i++) {
+            if (matchers.length != actual.length || !matchers[i].match(actual[i]).matched()) {
+                fail(
+                    Expected.of(List.of(matchers)),
+                    unexpected(List.of(actual)),
+                    contextBuilder().subject(link).build(),
+                    e -> "type parameters are not correct"
+                );
+            }
+        }
+    }
+
+    /**
      * Assert that a method with the given characteristics exists in the given {@link TypeLink}.
      *
      * @param link    the {@link TypeLink} to search in
@@ -209,10 +274,10 @@ public class Assertions3 {
         if (method != null) {
             return method;
         }
-        var methodName = ENVIRONMENT.getStringifier().stringify(matcher);
+        var matcherStr = ENVIRONMENT.getStringifier().stringify(matcher);
         return fail(
             contextBuilder().subject(link).build(),
-            e -> format("there is no method %s with expected characteristics", tt(methodName))
+            e -> format("there is no method with expected characteristics %s", tt(matcherStr))
         );
     }
 
@@ -354,6 +419,31 @@ public class Assertions3 {
     }
 
     /**
+     * Asserts that the given {@link MethodLink} has the correct throws.
+     *
+     * @param link     the {@link MethodLink} to check
+     * @param matchers the {@link Matcher}s to match the throws against
+     * @return the {@link MethodLink} if it has the correct throws
+     */
+    public static MethodLink assertCorrectThrows(MethodLink link, Matcher<? super TypeLink>... matchers) {
+        final var exceptionTypes = stream(link.reflection().getExceptionTypes())
+            .map(BasicTypeLink::of)
+            .toList();
+        for (var matcher : matchers) {
+            if (exceptionTypes.stream().anyMatch(matcher.predicate())) {
+                continue;
+            }
+            return fail(
+                of(stream(matchers).map(Matcher::object).toList()),
+                   unexpected(exceptionTypes),
+                   contextBuilder().subject(link).build(),
+                e -> "throws is not correct"
+            );
+        }
+        return link;
+    }
+
+    /**
      * Asserts that the given {@link FieldLink} implements the given interfaces.
      *
      * @param link  the {@link FieldLink} to check
@@ -367,5 +457,98 @@ public class Assertions3 {
             .map(BasicReflectionMatchers::sameType)
             .toArray(Matcher[]::new)
         );
+    }
+
+    /**
+     * Asserts that the given {@link MethodLink} has the same signature as the given {@link MethodLink}.
+     *
+     * @param expected             a {@link MethodLink} to compare against
+     * @param actual               a {@link MethodLink} to check
+     * @param verifyTypeParameters whether to verify the type parameters
+     * @param ignoredModifiers     modifiers to ignore
+     * @param <T>                  the type of the {@link MethodLink}
+     */
+    @SuppressWarnings("unchecked")
+    public static <T extends MethodLink> void assertSameSignature(
+        T expected,
+        T actual,
+        boolean verifyTypeParameters,
+        Modifier... ignoredModifiers
+    ) {
+        final String baseErrorMessage = "Method Signature is not correct.";
+        // name
+        if (!expected.name().equals(actual.name())) {
+            fail(
+                of(expected.name()),
+                unexpected(actual.name()),
+                contextBuilder().subject(expected).build(),
+                e -> baseErrorMessage + " Incorrect name."
+            );
+        }
+
+        // modifiers
+        assertCorrectModifiers(
+            actual,
+            stream(Modifier.fromIntPositive(expected.modifiers()))
+                .filter(Predicate.not(List.of(ignoredModifiers)::contains))
+                .toArray(Modifier[]::new)
+        );
+
+        // return type
+        if (!expected.returnType().equals(actual.returnType())) {
+            fail(
+                of(expected.returnType()),
+                unexpected(actual.returnType()),
+                contextBuilder().subject(expected).build(),
+                e -> baseErrorMessage + " Incorrect return type."
+            );
+        }
+        // parameters
+        assertCorrectParameters(expected, actual.typeList().stream().map(BasicReflectionMatchers::sameType)
+            .toArray(Matcher[]::new));
+
+        // type parameters
+        if (verifyTypeParameters) {
+            assertCorrectTypeParameters(actual, stream(expected.reflection().getTypeParameters())
+                .map(BasicReflectionMatchers::sameTypeVariable)
+                .toArray(Matcher[]::new));
+        }
+
+        // throws
+        assertCorrectThrows(actual, stream(expected.reflection().getExceptionTypes())
+            .map(BasicReflectionMatchers::sameType)
+            .toArray(Matcher[]::new));
+    }
+
+    /**
+     * Asserts that the given {@link MethodLink} has the same signature as the given {@link MethodLink}.
+     *
+     * @param expected the {@link MethodLink} to compare against
+     * @param actual   the {@link MethodLink} to check
+     */
+    public void assertSameSignature(MethodLink expected, MethodLink actual) {
+        assertSameSignature(expected, actual, true);
+    }
+
+    /**
+     * Asserts that an interface method is implemented in the given {@link TypeLink}. This method checks that the
+     * method has the correct signature and that it is annotated with {@link Override}.
+     *
+     * @param link            the {@link TypeLink} to check for the implementation
+     * @param interfaceMethod the {@link MethodLink} of the interface method
+     */
+    public static MethodLink assertImplementsInterfaceMethod(TypeLink link, MethodLink interfaceMethod) {
+        var method = (BasicMethodLink) assertMethodExists(
+            link,
+            BasicReflectionMatchers.sameTypes(interfaceMethod.typeList().toArray(TypeLink[]::new))
+        );
+        assertSameSignature(interfaceMethod, method, false, Modifier.ABSTRACT);
+        if (!method.getCtElement().hasAnnotation(Override.class)) {
+            fail(
+                emptyContext(),
+                e -> "Method does not have an @Override annotation."
+            );
+        }
+        return method;
     }
 }

--- a/tutor/src/main/java/org/tudalgo/algoutils/tutor/general/assertions/Assertions3.java
+++ b/tutor/src/main/java/org/tudalgo/algoutils/tutor/general/assertions/Assertions3.java
@@ -64,10 +64,10 @@ public class Assertions3 {
         if (match != null) {
             return match;
         }
-        var typeName = ENVIRONMENT.getStringifier().stringify(matcher);
+        var matcherStr = ENVIRONMENT.getStringifier().stringify(matcher);
         return fail(
             emptyContext(),
-            e -> format("type %s does not exist with expected characteristics", tt(typeName))
+            e -> format("there is no Type with expected characteristics %s", tt(matcherStr))
         );
     }
 
@@ -294,9 +294,13 @@ public class Assertions3 {
             return constructor;
         }
         var nameOfType = ENVIRONMENT.getStringifier().stringify(link);
+        var characteristics = ENVIRONMENT.getStringifier().stringify(matcher);
         return fail(
             contextBuilder().subject(link).build(),
-            e -> "there is no constructor of class %s with expected characteristics".formatted(tt(nameOfType))
+            e -> "there is no constructor of class %s with expected characteristics %s".formatted(
+                tt(nameOfType),
+                tt(characteristics)
+            )
         );
     }
 
@@ -434,9 +438,9 @@ public class Assertions3 {
                 continue;
             }
             return fail(
-                of(stream(matchers).map(Matcher::object).toList()),
-                   unexpected(exceptionTypes),
-                   contextBuilder().subject(link).build(),
+                of(stream(matchers).map(Matcher::characteristic).toList()),
+                unexpected(exceptionTypes),
+                contextBuilder().subject(link).build(),
                 e -> "throws is not correct"
             );
         }

--- a/tutor/src/main/java/org/tudalgo/algoutils/tutor/general/assertions/Assertions3.java
+++ b/tutor/src/main/java/org/tudalgo/algoutils/tutor/general/assertions/Assertions3.java
@@ -536,12 +536,13 @@ public class Assertions3 {
 
     /**
      * Asserts that an interface method is implemented in the given {@link TypeLink}. This method checks that the
-     * method has the correct signature and that it is annotated with {@link Override}.
+     * method has the correct signature and, if strict is true, that it has an @Override annotation.
      *
      * @param link            the {@link TypeLink} to check for the implementation
      * @param interfaceMethod the {@link MethodLink} of the interface method
+     * @param strict          whether to check for the @Override annotation
      */
-    public static MethodLink assertImplementsInterfaceMethod(TypeLink link, MethodLink interfaceMethod) {
+    public static MethodLink assertImplementsInterfaceMethod(TypeLink link, MethodLink interfaceMethod, boolean strict) {
         var method = (BasicMethodLink) assertMethodExists(
             link,
             BasicReflectionMatchers.sameTypes(interfaceMethod.typeList().toArray(TypeLink[]::new))
@@ -554,5 +555,17 @@ public class Assertions3 {
             );
         }
         return method;
+    }
+
+    /**
+     * Asserts that an interface method is implemented in the given {@link TypeLink}. This method checks that the
+     * method has the correct signature and that it has an @Override annotation by calling
+     * {@link #assertImplementsInterfaceMethod(TypeLink, MethodLink, boolean)} with strict = true.
+     *
+     * @param link            the {@link TypeLink} to check for the implementation
+     * @param interfaceMethod the {@link MethodLink} of the interface method
+     */
+    public static MethodLink assertImplementsInterfaceMethod(TypeLink link, MethodLink interfaceMethod) {
+        return assertImplementsInterfaceMethod(link, interfaceMethod, true);
     }
 }

--- a/tutor/src/main/java/org/tudalgo/algoutils/tutor/general/assertions/Assertions3.java
+++ b/tutor/src/main/java/org/tudalgo/algoutils/tutor/general/assertions/Assertions3.java
@@ -15,24 +15,33 @@ import static org.tudalgo.algoutils.tutor.general.stringify.HTML.tt;
 import org.tudalgo.algoutils.tutor.general.Environment;
 import org.tudalgo.algoutils.tutor.general.assertions.expected.Expected;
 import org.tudalgo.algoutils.tutor.general.basic.BasicEnvironment;
+import org.tudalgo.algoutils.tutor.general.match.BasicReflectionMatchers;
+import org.tudalgo.algoutils.tutor.general.match.BasicStringMatchers;
 import org.tudalgo.algoutils.tutor.general.match.Matcher;
 import org.tudalgo.algoutils.tutor.general.match.Stringifiable;
-import org.tudalgo.algoutils.tutor.general.reflections.ConstructorLink;
-import org.tudalgo.algoutils.tutor.general.reflections.EnumConstantLink;
-import org.tudalgo.algoutils.tutor.general.reflections.FieldLink;
-import org.tudalgo.algoutils.tutor.general.reflections.MethodLink;
-import org.tudalgo.algoutils.tutor.general.reflections.Modifier;
-import org.tudalgo.algoutils.tutor.general.reflections.PackageLink;
-import org.tudalgo.algoutils.tutor.general.reflections.TypeLink;
-import org.tudalgo.algoutils.tutor.general.reflections.WithModifiers;
-import org.tudalgo.algoutils.tutor.general.reflections.WithTypeList;
+import org.tudalgo.algoutils.tutor.general.reflections.*;
 import org.tudalgo.algoutils.tutor.general.stringify.HTML;
 
+/**
+ * <p>The Assertions3 class is a collection of test utils for verifying the declarations of classes, methods, fields,
+ * etc.
+ * </p>
+ */
 @SuppressWarnings("unused")
 public class Assertions3 {
 
+    /**
+     * The {@link Environment} to use.
+     */
     private static final Environment ENVIRONMENT = BasicEnvironment.getInstance();
 
+    /**
+     * <p>Asserts that the given {@link TypeLink} exists in the given {@link PackageLink}.</p>
+     *
+     * @param linkToPackage the {@link PackageLink} to search in
+     * @param matcher       the {@link Matcher} to match the {@link TypeLink} against
+     * @return the {@link TypeLink} if it exists
+     */
     public static TypeLink assertTypeExists(
         PackageLink linkToPackage,
         Matcher<? super TypeLink> matcher
@@ -48,6 +57,25 @@ public class Assertions3 {
         );
     }
 
+    /**
+     * <p>Asserts that the given {@link TypeLink} exists in the given {@link PackageLink}.</p>
+     *
+     * @param linkToPackage the {@link PackageLink} to search in
+     * @param name          the name of the {@link TypeLink}
+     * @return the {@link TypeLink} if it exists
+     */
+    public static TypeLink assertTypeExists(PackageLink linkToPackage, String name) {
+        return assertTypeExists(linkToPackage, BasicStringMatchers.identical(name));
+    }
+
+    /**
+     * <p>Asserts that the given {@link org.tudalgo.algoutils.tutor.general.reflections.Link} has the correct modifiers.</p>
+     *
+     * @param link       the {@link org.tudalgo.algoutils.tutor.general.reflections.Link} to check
+     * @param attributes the {@link Modifier}s that should be present
+     * @param <T>        the type of the {@link org.tudalgo.algoutils.tutor.general.reflections.Link}
+     * @return the {@link org.tudalgo.algoutils.tutor.general.reflections.Link} if it has the correct modifiers
+     */
     public static <T extends WithModifiers> T assertCorrectModifiers(
         T link,
         Modifier... attributes
@@ -69,6 +97,13 @@ public class Assertions3 {
         );
     }
 
+    /**
+     * <p>Asserts that the given {@link MethodLink} has the correct return type.</p>
+     *
+     * @param link    the {@link MethodLink} to check
+     * @param matcher the {@link Matcher} to match the return type against
+     * @return the {@link MethodLink} if it has the correct return type
+     */
     public static MethodLink assertCorrectReturnType(MethodLink link, Matcher<TypeLink> matcher) {
         if (matcher.match(link.returnType()).matched()) {
             return link;
@@ -82,6 +117,35 @@ public class Assertions3 {
         );
     }
 
+    /**
+     * <p>Asserts that the given {@link MethodLink} has the correct return type.</p>
+     *
+     * @param link the {@link MethodLink} to check
+     * @param type the {@link TypeLink} to match the return type against
+     * @return the {@link MethodLink} if it has the correct return type
+     */
+    public static MethodLink assertCorrectReturnType(MethodLink link, TypeLink type) {
+        return assertCorrectReturnType(link, BasicReflectionMatchers.sameType(type));
+    }
+
+    /**
+     * <p>Asserts that the given {@link MethodLink} has the correct return type.</p>
+     *
+     * @param link the {@link MethodLink} to check
+     * @param type the {@link Class} to match the return type against
+     * @return the {@link MethodLink} if it has the correct return type
+     */
+    public static MethodLink assertCorrectReturnType(MethodLink link, Class<?> type) {
+        return assertCorrectReturnType(link, BasicTypeLink.of(type));
+    }
+
+    /**
+     * <p>Asserts that the given {@link EnumConstantLink} exists in the enum of the given {@link TypeLink}.</p>
+     *
+     * @param link    the {@link TypeLink} of the enum to search in
+     * @param matcher the {@link Matcher} to match the {@link EnumConstantLink} against
+     * @return the {@link EnumConstantLink} if it exists
+     */
     public static EnumConstantLink assertHasEnumConstant(TypeLink link, Matcher<? super Stringifiable> matcher) {
         var constant = link.getEnumConstant(matcher);
         if (constant != null) {
@@ -94,6 +158,25 @@ public class Assertions3 {
         );
     }
 
+    /**
+     * <p>Asserts that the given {@link EnumConstantLink} exists in the enum of the given {@link TypeLink}.</p>
+     *
+     * @param link the {@link TypeLink} of the enum to search in
+     * @param name the name of the {@link EnumConstantLink}
+     * @return the {@link EnumConstantLink} if it exists
+     */
+    public static EnumConstantLink assertHasEnumConstant(TypeLink link, String name) {
+        return assertHasEnumConstant(link, BasicStringMatchers.identical(name));
+    }
+
+    /**
+     * Assert that the parameters of the given {@link WithTypeList} are correctly declared.
+     *
+     * @param withParameters the {@link WithTypeList} to check
+     * @param matchers       the {@link Matcher}s to match the parameters against
+     * @param <T>            the type of the {@link WithTypeList}
+     * @return the {@link WithTypeList} if the parameters are correct
+     */
     @SafeVarargs
     public static <T extends WithTypeList> T assertCorrectParameters(
         T withParameters,
@@ -114,6 +197,33 @@ public class Assertions3 {
         return withParameters;
     }
 
+    /**
+     * Assert that the parameters of the given {@link WithTypeList} are correctly declared.
+     *
+     * @param withParameters the {@link WithTypeList} to check
+     * @param types          the {@link Class}es to match the parameters against
+     * @param <T>            the type of the {@link WithTypeList}
+     * @return the {@link WithTypeList} if the parameters are correct
+     */
+    @SuppressWarnings("unchecked")
+    public static <T extends WithTypeList> T assertCorrectParameters(
+        T withParameters,
+        Class<?>... types
+    ) {
+        return assertCorrectParameters(withParameters, stream(types)
+            .map(BasicTypeLink::of)
+            .map(BasicReflectionMatchers::sameType)
+            .toArray(Matcher[]::new)
+        );
+    }
+
+    /**
+     * Assert that a method with the given characteristics exists in the given {@link TypeLink}.
+     *
+     * @param link    the {@link TypeLink} to search in
+     * @param matcher the {@link Matcher} to match the {@link MethodLink} against
+     * @return the {@link MethodLink} if it exists
+     */
     public static MethodLink assertMethodExists(TypeLink link, Matcher<? super MethodLink> matcher) {
         var method = link.getMethod(matcher);
         if (method != null) {
@@ -126,6 +236,13 @@ public class Assertions3 {
         );
     }
 
+    /**
+     * Assert that a constructor with the given characteristics exists in the given {@link TypeLink}.
+     *
+     * @param link    the {@link TypeLink} to search in
+     * @param matcher the {@link Matcher} to match the {@link ConstructorLink} against
+     * @return the {@link ConstructorLink} if it exists
+     */
     public static ConstructorLink assertConstructorExists(TypeLink link, Matcher<? super ConstructorLink> matcher) {
         var constructor = link.getConstructor(matcher);
         if (constructor != null) {
@@ -138,6 +255,13 @@ public class Assertions3 {
         );
     }
 
+    /**
+     * Assert that a field with the given characteristics exists in the given {@link TypeLink}.
+     *
+     * @param link    the {@link TypeLink} to search in
+     * @param matcher the {@link Matcher} to match the {@link FieldLink} against
+     * @return the {@link FieldLink} if it exists
+     */
     public static FieldLink assertFieldExists(TypeLink link, Matcher<? super FieldLink> matcher) {
         var field = link.getField(matcher);
         if (field != null) {
@@ -150,6 +274,13 @@ public class Assertions3 {
         );
     }
 
+    /**
+     * Asserts that the given {@link FieldLink} has the correct static type.
+     *
+     * @param link    the {@link FieldLink} to check
+     * @param matcher the {@link Matcher} to match the static type against
+     * @return the {@link FieldLink} if it has the correct static type
+     */
     public static FieldLink assertCorrectStaticType(FieldLink link, Matcher<? super FieldLink> matcher) {
         if (matcher.match(link).matched()) {
             return link;
@@ -163,6 +294,13 @@ public class Assertions3 {
         );
     }
 
+    /**
+     * Asserts that the given {@link FieldLink} has the correct super type.
+     *
+     * @param link    the {@link FieldLink} to check
+     * @param matcher the {@link Matcher} to match the super type against
+     * @return the {@link FieldLink} if it has the correct super type
+     */
     public static TypeLink assertCorrectSuperType(TypeLink link, Matcher<? super TypeLink> matcher) {
         if (matcher.match(link.superType()).matched()) {
             return link;
@@ -175,6 +313,35 @@ public class Assertions3 {
         );
     }
 
+    /**
+     * Asserts that the given {@link FieldLink} has the correct super type.
+     *
+     * @param link the {@link FieldLink} to check
+     * @param type the {@link TypeLink} to match the super type against
+     * @return the {@link FieldLink} if it has the correct super type
+     */
+    public static TypeLink assertCorrectSuperType(TypeLink link, TypeLink type) {
+        return assertCorrectSuperType(link, BasicReflectionMatchers.sameType(type));
+    }
+
+    /**
+     * Asserts that the given {@link FieldLink} has the correct super type.
+     *
+     * @param link the {@link FieldLink} to check
+     * @param type the {@link Class} to match the super type against
+     * @return the {@link FieldLink} if it has the correct super type
+     */
+    public static TypeLink assertCorrectSuperType(TypeLink link, Class<?> type) {
+        return assertCorrectSuperType(link, BasicTypeLink.of(type));
+    }
+
+    /**
+     * Asserts that the given {@link FieldLink} implements the given interfaces.
+     *
+     * @param link     the {@link FieldLink} to check
+     * @param matchers the {@link Matcher}s to match the interfaces against
+     * @return the {@link FieldLink} if it implements the given interfaces
+     */
     @SafeVarargs
     public static TypeLink assertCorrectInterfaces(TypeLink link, Matcher<? super TypeLink>... matchers) {
         for (var matcher : matchers) {
@@ -189,5 +356,36 @@ public class Assertions3 {
             );
         }
         return link;
+    }
+
+    /**
+     * Asserts that the given {@link FieldLink} implements the given interfaces.
+     *
+     * @param link  the {@link FieldLink} to check
+     * @param types the {@link TypeLink}s to match the interfaces against
+     * @return the {@link FieldLink} if it implements the given interfaces
+     */
+    @SuppressWarnings("unchecked")
+    public static TypeLink assertCorrectInterfaces(TypeLink link, TypeLink... types) {
+        return assertCorrectInterfaces(link, stream(types)
+            .map(BasicReflectionMatchers::sameType)
+            .toArray(Matcher[]::new)
+        );
+    }
+
+    /**
+     * Asserts that the given {@link FieldLink} implements the given interfaces.
+     *
+     * @param link  the {@link FieldLink} to check
+     * @param types the {@link Class}es to match the interfaces against
+     * @return the {@link FieldLink} if it implements the given interfaces
+     */
+    @SuppressWarnings("unchecked")
+    public static TypeLink assertCorrectInterfaces(TypeLink link, Class<?>... types) {
+        return assertCorrectInterfaces(link, stream(types)
+            .map(BasicTypeLink::of)
+            .map(BasicReflectionMatchers::sameType)
+            .toArray(Matcher[]::new)
+        );
     }
 }

--- a/tutor/src/main/java/org/tudalgo/algoutils/tutor/general/assertions/Assertions3.java
+++ b/tutor/src/main/java/org/tudalgo/algoutils/tutor/general/assertions/Assertions3.java
@@ -198,26 +198,6 @@ public class Assertions3 {
     }
 
     /**
-     * Assert that the parameters of the given {@link WithTypeList} are correctly declared.
-     *
-     * @param withParameters the {@link WithTypeList} to check
-     * @param types          the {@link Class}es to match the parameters against
-     * @param <T>            the type of the {@link WithTypeList}
-     * @return the {@link WithTypeList} if the parameters are correct
-     */
-    @SuppressWarnings("unchecked")
-    public static <T extends WithTypeList> T assertCorrectParameters(
-        T withParameters,
-        Class<?>... types
-    ) {
-        return assertCorrectParameters(withParameters, stream(types)
-            .map(BasicTypeLink::of)
-            .map(BasicReflectionMatchers::sameType)
-            .toArray(Matcher[]::new)
-        );
-    }
-
-    /**
      * Assert that a method with the given characteristics exists in the given {@link TypeLink}.
      *
      * @param link    the {@link TypeLink} to search in

--- a/tutor/src/main/java/org/tudalgo/algoutils/tutor/general/assertions/Assertions4.java
+++ b/tutor/src/main/java/org/tudalgo/algoutils/tutor/general/assertions/Assertions4.java
@@ -209,8 +209,14 @@ public class Assertions4 {
     @SuppressWarnings("unchecked")
     public static Matcher<CtElement>[] buildCtElementBlacklist(BasicMethodLink... links) {
         return Arrays.stream(links).map(m -> Matcher.of(
-            ct -> ct instanceof CtInvocation<?> i && i.getExecutable() != null && i.getExecutable().getActualMethod() != null && i.getExecutable().getActualMethod().equals(m.reflection()),
-            "method " + BasicEnvironment.getInstance().getStringifier().stringify(m.reflection())
+            ct -> ct instanceof CtInvocation<?> i
+                && i.getExecutable() != null
+                && i.getExecutable().getActualMethod() != null
+                && i.getExecutable().getActualMethod().equals(m.reflection()),
+            "method " + BasicEnvironment
+                .getInstance()
+                .getStringifier()
+                .stringify(m.reflection())
         )).toArray(Matcher[]::new);
     }
 
@@ -221,7 +227,11 @@ public class Assertions4 {
      * @return the matchers
      */
     public static Matcher<CtElement>[] buildCtElementBlacklist(Method... links) {
-        return buildCtElementBlacklist(Arrays.stream(links).map(BasicMethodLink::of).toArray(BasicMethodLink[]::new));
+        return buildCtElementBlacklist(
+            Arrays.stream(links)
+                .map(BasicMethodLink::of)
+                .toArray(BasicMethodLink[]::new)
+        );
     }
 
     /**

--- a/tutor/src/main/java/org/tudalgo/algoutils/tutor/general/assertions/Assertions4.java
+++ b/tutor/src/main/java/org/tudalgo/algoutils/tutor/general/assertions/Assertions4.java
@@ -4,11 +4,9 @@ import org.eclipse.jdt.core.dom.DoStatement;
 import org.eclipse.jdt.core.dom.WhileStatement;
 import org.tudalgo.algoutils.tutor.general.assertions.expected.ExpectedObjects;
 import org.tudalgo.algoutils.tutor.general.basic.BasicEnvironment;
-import org.tudalgo.algoutils.tutor.general.match.BasicReflectionMatchers;
+import org.tudalgo.algoutils.tutor.general.callable.ObjectCallable;
 import org.tudalgo.algoutils.tutor.general.match.Matcher;
 import org.tudalgo.algoutils.tutor.general.reflections.BasicMethodLink;
-import org.tudalgo.algoutils.tutor.general.reflections.Link;
-import org.tudalgo.algoutils.tutor.general.reflections.MethodLink;
 import org.tudalgo.algoutils.tutor.general.stringify.HTML;
 import spoon.reflect.code.CtBlock;
 import spoon.reflect.code.CtComment;
@@ -224,6 +222,25 @@ public class Assertions4 {
      */
     public static Matcher<CtElement>[] buildCtElementBlacklist(Method... links) {
         return buildCtElementBlacklist(Arrays.stream(links).map(BasicMethodLink::of).toArray(BasicMethodLink[]::new));
+    }
+
+    /**
+     * Builds a list of {@link Matcher}s for the given {@link Method}s.
+     *
+     * @param links Supplier for the links, exceptions are properly handled
+     * @return the matchers
+     */
+    @SafeVarargs
+    public static Matcher<CtElement>[] buildCtElementBlacklist(ObjectCallable<Method>... links) {
+        return buildCtElementBlacklist(
+            Arrays.stream(links)
+                .map(l -> Assertions2.callObject(
+                    l,
+                    Assertions2.emptyContext(),
+                    r -> "The desired Method could not be retrieved. This is likely an Error in the tests."
+                ))
+                .toArray(Method[]::new)
+        );
     }
 }
 

--- a/tutor/src/main/java/org/tudalgo/algoutils/tutor/general/assertions/Assertions4.java
+++ b/tutor/src/main/java/org/tudalgo/algoutils/tutor/general/assertions/Assertions4.java
@@ -25,6 +25,10 @@ import java.util.Set;
 import static org.tudalgo.algoutils.tutor.general.assertions.Assertions2.contextBuilder;
 import static org.tudalgo.algoutils.tutor.general.assertions.expected.Nothing.text;
 
+/**
+ * <p>The Assertions4 class provides methods for analyzing the source code of a student solution with Spoon. This includes
+ * utilities for checking for forbidden method calls, recursive method calls, and more.</p>
+ */
 @SuppressWarnings("unused")
 public class Assertions4 {
 

--- a/tutor/src/main/java/org/tudalgo/algoutils/tutor/general/assertions/Assertions4.java
+++ b/tutor/src/main/java/org/tudalgo/algoutils/tutor/general/assertions/Assertions4.java
@@ -211,7 +211,7 @@ public class Assertions4 {
     @SuppressWarnings("unchecked")
     public static Matcher<CtElement>[] buildCtElementBlacklist(BasicMethodLink... links) {
         return Arrays.stream(links).map(m -> Matcher.of(
-            ct -> ct instanceof CtInvocation<?> i && i.getExecutable().getActualMethod().equals(m.reflection()),
+            ct -> ct instanceof CtInvocation<?> i && i.getExecutable() != null && i.getExecutable().getActualMethod() != null && i.getExecutable().getActualMethod().equals(m.reflection()),
             "method " + BasicEnvironment.getInstance().getStringifier().stringify(m.reflection())
         )).toArray(Matcher[]::new);
     }

--- a/tutor/src/main/java/org/tudalgo/algoutils/tutor/general/assertions/Assertions4.java
+++ b/tutor/src/main/java/org/tudalgo/algoutils/tutor/general/assertions/Assertions4.java
@@ -194,7 +194,7 @@ public class Assertions4 {
             }
             Assertions2.fail(
                 context,
-                r -> "forbidden element " + HTML.tt(e.object().toString()) + " was used."
+                r -> "forbidden statement with characteristic " + HTML.tt(e.characteristic()) + " was used."
             );
         }
     }

--- a/tutor/src/main/java/org/tudalgo/algoutils/tutor/general/assertions/basic/BasicResult.java
+++ b/tutor/src/main/java/org/tudalgo/algoutils/tutor/general/assertions/basic/BasicResult.java
@@ -58,7 +58,8 @@ public abstract class BasicResult<RT extends Result<RT, AT, TT, ET>, AT extends 
             throw new AssertionFailedError(
                 environment.getCommentFactory().comment((RT) this, context, preCommentSupplier),
                 expected().behavior(),
-                actual().behavior()
+                actual().behavior(),
+                cause()
             );
         //noinspection unchecked
         return (RT) this;

--- a/tutor/src/main/java/org/tudalgo/algoutils/tutor/general/match/BasicReflectionMatchers.java
+++ b/tutor/src/main/java/org/tudalgo/algoutils/tutor/general/match/BasicReflectionMatchers.java
@@ -13,7 +13,10 @@ public class BasicReflectionMatchers {
     }
 
     public static <T extends WithType> Matcher<T> sameType(TypeLink link) {
-        return Matcher.of(l -> Objects.equals(l.type(), link), link.reflection().getName());
+        return Matcher.of(
+            l -> Objects.equals(l.type(), link),
+            String.format("Same type: %s", link.reflection().getName())
+        );
     }
 
     public static <T extends WithType> Matcher<T> sameType(Class<?> clazz) {
@@ -28,10 +31,13 @@ public class BasicReflectionMatchers {
      */
     public static <T extends WithTypeList> Matcher<T> sameTypes(TypeLink... types) {
         var parameterList = List.of(types);
-        return Matcher.of(l -> l.typeList().equals(parameterList), String.format(
-            "Same parameter types: %s",
-            parameterList.stream().map(TypeLink::name).toList()
-        ));
+        return Matcher.of(
+            l -> l.typeList().equals(parameterList),
+            String.format(
+                "Same parameter types: %s",
+                parameterList.stream().map(TypeLink::name).toList()
+            )
+        );
     }
 
     /**
@@ -65,6 +71,9 @@ public class BasicReflectionMatchers {
      * @return the matcher matching the {@link TypeVariable}
      */
     public static Matcher<TypeVariable<?>> sameTypeVariable(TypeVariable<?> typeVariable) {
-        return Matcher.of(l -> l.equals(typeVariable), typeVariable);
+        return Matcher.of(
+            l -> l.equals(typeVariable),
+            String.format("Same generic type: %s", typeVariable.getName())
+        );
     }
 }

--- a/tutor/src/main/java/org/tudalgo/algoutils/tutor/general/match/BasicReflectionMatchers.java
+++ b/tutor/src/main/java/org/tudalgo/algoutils/tutor/general/match/BasicReflectionMatchers.java
@@ -1,11 +1,6 @@
 package org.tudalgo.algoutils.tutor.general.match;
 
-import org.tudalgo.algoutils.tutor.general.reflections.BasicTypeLink;
-import org.tudalgo.algoutils.tutor.general.reflections.Modifier;
-import org.tudalgo.algoutils.tutor.general.reflections.TypeLink;
-import org.tudalgo.algoutils.tutor.general.reflections.WithModifiers;
-import org.tudalgo.algoutils.tutor.general.reflections.WithType;
-import org.tudalgo.algoutils.tutor.general.reflections.WithTypeList;
+import org.tudalgo.algoutils.tutor.general.reflections.*;
 
 import java.lang.reflect.TypeVariable;
 import java.util.List;

--- a/tutor/src/main/java/org/tudalgo/algoutils/tutor/general/match/BasicReflectionMatchers.java
+++ b/tutor/src/main/java/org/tudalgo/algoutils/tutor/general/match/BasicReflectionMatchers.java
@@ -1,9 +1,16 @@
 package org.tudalgo.algoutils.tutor.general.match;
 
-import org.tudalgo.algoutils.tutor.general.reflections.*;
+import org.tudalgo.algoutils.tutor.general.reflections.BasicTypeLink;
+import org.tudalgo.algoutils.tutor.general.reflections.Modifier;
+import org.tudalgo.algoutils.tutor.general.reflections.TypeLink;
+import org.tudalgo.algoutils.tutor.general.reflections.WithModifiers;
+import org.tudalgo.algoutils.tutor.general.reflections.WithType;
+import org.tudalgo.algoutils.tutor.general.reflections.WithTypeList;
 
+import java.lang.reflect.TypeVariable;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Stream;
 
 public class BasicReflectionMatchers {
 
@@ -11,7 +18,7 @@ public class BasicReflectionMatchers {
     }
 
     public static <T extends WithType> Matcher<T> sameType(TypeLink link) {
-        return Matcher.of(l -> Objects.equals(l.type(), link), link);
+        return Matcher.of(l -> Objects.equals(l.type(), link), link.reflection().getName());
     }
 
     public static <T extends WithType> Matcher<T> sameType(Class<?> clazz) {
@@ -26,7 +33,10 @@ public class BasicReflectionMatchers {
      */
     public static <T extends WithTypeList> Matcher<T> sameTypes(TypeLink... types) {
         var parameterList = List.of(types);
-        return Matcher.of(l -> l.typeList().equals(parameterList));
+        return Matcher.of(l -> l.typeList().equals(parameterList), String.format(
+            "Same parameter types: %s",
+            parameterList.stream().map(TypeLink::name).toList()
+        ));
     }
 
     /**
@@ -37,13 +47,29 @@ public class BasicReflectionMatchers {
      * @return the matcher
      */
     public static <T extends WithModifiers> Matcher<T> hasModifiers(Modifier... modifiers) {
-        return Matcher.of(l -> {
-            for (var modifier : modifiers) {
-                if (!modifier.is(l.modifiers())) {
-                    return false;
+        return Matcher.of(
+            l -> {
+                for (var modifier : modifiers) {
+                    if (!modifier.is(l.modifiers())) {
+                        return false;
+                    }
                 }
-            }
-            return true;
-        });
+                return true;
+            },
+            String.format(
+                "Has modifiers: %s",
+                Stream.of(modifiers).map(Modifier::name).toList()
+            )
+        );
+    }
+
+    /**
+     * <p>A matcher matching a {@link TypeVariable} if the {@link TypeVariable} is equal to the given one.</p>
+     *
+     * @param typeVariable the {@link TypeVariable} to match against
+     * @return the matcher matching the {@link TypeVariable}
+     */
+    public static Matcher<TypeVariable<?>> sameTypeVariable(TypeVariable<?> typeVariable) {
+        return Matcher.of(l -> l.equals(typeVariable), typeVariable);
     }
 }

--- a/tutor/src/main/java/org/tudalgo/algoutils/tutor/general/match/BasicReflectionMatchers.java
+++ b/tutor/src/main/java/org/tudalgo/algoutils/tutor/general/match/BasicReflectionMatchers.java
@@ -14,6 +14,10 @@ public class BasicReflectionMatchers {
         return Matcher.of(l -> Objects.equals(l.type(), link), link);
     }
 
+    public static <T extends WithType> Matcher<T> sameType(Class<?> clazz) {
+        return sameType(BasicTypeLink.of(clazz));
+    }
+
     /**
      * <p>A matcher matching an object if the object has the same types as given.</p>
      *

--- a/tutor/src/main/java/org/tudalgo/algoutils/tutor/general/match/BasicStringMatchers.java
+++ b/tutor/src/main/java/org/tudalgo/algoutils/tutor/general/match/BasicStringMatchers.java
@@ -11,4 +11,15 @@ public final class BasicStringMatchers {
     public static <T extends Stringifiable> Matcher<T> identical(String string) {
         return Matcher.of(stringifiable -> stringifiable.string().equals(string), string);
     }
+
+    public static <T extends Stringifiable> Matcher<T> identicalIgnoreCase(String string) {
+        return Matcher.of(stringifiable -> stringifiable.string().equalsIgnoreCase(string), string);
+    }
+
+    public static <T extends Stringifiable> Matcher<T> similar(String string, double minimumSimilarity) {
+        return Matcher.of(
+            stringifiable -> MatchingUtils.similarity(stringifiable.string(), string) >= minimumSimilarity,
+            string
+        );
+    }
 }

--- a/tutor/src/main/java/org/tudalgo/algoutils/tutor/general/match/Match.java
+++ b/tutor/src/main/java/org/tudalgo/algoutils/tutor/general/match/Match.java
@@ -71,7 +71,7 @@ public interface Match<T> extends Comparable<Match<T>> {
      *
      * @return if this match is a negative match
      */
-    default boolean negative() {
+    default boolean isNegative() {
         return !matched();
     }
 

--- a/tutor/src/main/java/org/tudalgo/algoutils/tutor/general/match/Matcher.java
+++ b/tutor/src/main/java/org/tudalgo/algoutils/tutor/general/match/Matcher.java
@@ -2,6 +2,7 @@ package org.tudalgo.algoutils.tutor.general.match;
 
 import org.tudalgo.algoutils.tutor.general.basic.BasicEnvironment;
 
+import java.util.function.Function;
 import java.util.function.Predicate;
 
 /**
@@ -136,6 +137,20 @@ public interface Matcher<T> {
         return Matcher.of(
             this.predicate().or(other.predicate()),
             String.format("(%s) or (%s)", this.characteristic(), other.characteristic())
+        );
+    }
+
+    /**
+     * <p>Returns a new matcher that maps the given mapper before matching with this matcher.</p>
+     *
+     * @param mapper the mapper
+     * @param <U>    the type of the object to match
+     * @return the new matcher
+     */
+    default <U> Matcher<U> map(Function<U, T> mapper) {
+        return Matcher.of(
+            e -> this.match(mapper.apply(e)).matched(),
+            this.characteristic()
         );
     }
 }

--- a/tutor/src/main/java/org/tudalgo/algoutils/tutor/general/match/Matcher.java
+++ b/tutor/src/main/java/org/tudalgo/algoutils/tutor/general/match/Matcher.java
@@ -1,5 +1,7 @@
 package org.tudalgo.algoutils.tutor.general.match;
 
+import org.tudalgo.algoutils.tutor.general.basic.BasicEnvironment;
+
 import java.util.function.Predicate;
 
 /**
@@ -7,6 +9,7 @@ import java.util.function.Predicate;
  *
  * @param <T> the type of object to match
  */
+@FunctionalInterface
 public interface Matcher<T> {
 
     /**
@@ -29,7 +32,15 @@ public interface Matcher<T> {
         return Match::negative;
     }
 
-    static <T> Matcher<T> of(Predicate<T> matcher, Object object) {
+    /**
+     * <p>Creates a Matcher with the given Characteristic</p>
+     *
+     * @param matcher        the matcher predicate
+     * @param characteristic the characteristic of the matcher
+     * @param <T>            the type of object to match
+     * @return the matcher
+     */
+    static <T> Matcher<T> of(Predicate<T> matcher, String characteristic) {
         return new Matcher<T>() {
             @Override
             public <ST extends T> Match<ST> match(ST object) {
@@ -37,10 +48,23 @@ public interface Matcher<T> {
             }
 
             @Override
-            public Object object() {
-                return object;
+            public String characteristic() {
+                return characteristic;
             }
         };
+    }
+
+    /**
+     * <p>Creates a Matcher with the given Characteristic</p>
+     *
+     * @param matcher the matcher predicate
+     * @param object  the characteristic of the matcher. Will be stringified using the default
+     *                {@link org.tudalgo.algoutils.tutor.general.stringify.Stringifier}
+     * @param <T>     the type of object to match
+     * @return the matcher
+     */
+    static <T> Matcher<T> of(Predicate<T> matcher, Object object) {
+        return of(matcher, BasicEnvironment.getInstance().getStringifier().stringify(object));
     }
 
     static <T> Matcher<T> of(Predicate<T> matcher) {
@@ -56,7 +80,12 @@ public interface Matcher<T> {
      */
     <ST extends T> Match<ST> match(ST object);
 
-    default Object object() {
+    /**
+     * The characteristic of this matcher. This is used to describe the matcher in error messages.
+     *
+     * @return the characteristic of this matcher
+     */
+    default String characteristic() {
         return null;
     }
 
@@ -76,26 +105,37 @@ public interface Matcher<T> {
      * @return the negated matcher
      */
     default Matcher<T> negate() {
-        return Matcher.of(Predicate.not(this.predicate()), this.object());
+        return Matcher.of(
+            Predicate.not(this.predicate()),
+            String.format("not (%s)", this.characteristic())
+        );
     }
 
     /**
-     * <p>Returns a new matcher that logically combines the current matcher with the given matcher using the logical {@code and} operator.</p>
+     * <p>Returns a new matcher that logically combines the current matcher with the given matcher using the logical
+     * {@code and} operator.</p>
      *
      * @param other the other matcher
      * @return the new matcher
      */
     default Matcher<T> and(Matcher<? super T> other) {
-        return Matcher.of(this.predicate().and(other.predicate()), this.object() == null ? other.object() : this.object());
+        return Matcher.of(
+            this.predicate().and(other.predicate()),
+            String.format("(%s) and (%s)", this.characteristic(), other.characteristic())
+        );
     }
 
     /**
-     * <p>Returns a new matcher that logically combines the current matcher with the given matcher using the logical {@code or} operator.</p>
+     * <p>Returns a new matcher that logically combines the current matcher with the given matcher using the logical
+     * {@code or} operator.</p>
      *
      * @param other the other matcher
      * @return the new matcher
      */
     default Matcher<T> or(Matcher<T> other) {
-        return Matcher.of(this.predicate().or(other.predicate()), this.object());
+        return Matcher.of(
+            this.predicate().or(other.predicate()),
+            String.format("(%s) or (%s)", this.characteristic(), other.characteristic())
+        );
     }
 }

--- a/tutor/src/main/java/org/tudalgo/algoutils/tutor/general/reflections/BasicPackageLink.java
+++ b/tutor/src/main/java/org/tudalgo/algoutils/tutor/general/reflections/BasicPackageLink.java
@@ -17,14 +17,31 @@ public class BasicPackageLink extends BasicLink implements PackageLink {
         this.classes = classes.stream().map(BasicTypeLink::of).toList();
     }
 
-    public static BasicPackageLink of(String name) {
+    /**
+     * Factory method for creating a package link
+     *
+     * @param name      package name
+     * @param recursive whether to include sub-packages
+     * @return package link
+     */
+    public static BasicPackageLink of(String name, boolean recursive) {
         List<Class<?>> classes;
         try {
-            classes = Arrays.stream(ReflectUtils.getClasses(name)).toList();
+            classes = Arrays.stream(ReflectUtils.getClasses(name, recursive)).toList();
         } catch (IOException e) {
             throw new AssertionFailedError("internal error in class BasicPackageLink");
         }
         return INSTANCES.computeIfAbsent(name, n -> new BasicPackageLink(n, classes));
+    }
+
+    /**
+     * Overloaded method for non-recursive package link
+     *
+     * @param name package name
+     * @return package link
+     */
+    public static BasicPackageLink of(String name) {
+        return of(name, false);
     }
 
     @Override

--- a/tutor/src/main/java/org/tudalgo/algoutils/tutor/general/reflections/ConstructorLink.java
+++ b/tutor/src/main/java/org/tudalgo/algoutils/tutor/general/reflections/ConstructorLink.java
@@ -1,5 +1,7 @@
 package org.tudalgo.algoutils.tutor.general.reflections;
 
+import java.lang.reflect.Constructor;
+
 public interface ConstructorLink extends Link, WithType, WithTypeList, WithModifiers {
 
     @Override
@@ -8,4 +10,7 @@ public interface ConstructorLink extends Link, WithType, WithTypeList, WithModif
     }
 
     <T> T invoke(Object... arguments) throws Throwable;
+
+    @Override
+    Constructor<?> reflection();
 }

--- a/tutor/src/main/java/org/tudalgo/algoutils/tutor/general/reflections/Modifier.java
+++ b/tutor/src/main/java/org/tudalgo/algoutils/tutor/general/reflections/Modifier.java
@@ -1,13 +1,20 @@
 package org.tudalgo.algoutils.tutor.general.reflections;
 
+import java.util.Arrays;
 import java.util.function.Predicate;
 
+/**
+ * <p>A list of modifiers that can be used to check if a modifier is present in a given modifier.</p>
+ */
 public enum Modifier {
 
     PUBLIC(java.lang.reflect.Modifier::isPublic),
     PROTECTED(java.lang.reflect.Modifier::isProtected),
     PRIVATE(java.lang.reflect.Modifier::isPrivate),
-    DEFAULT_ACCESS(m -> !java.lang.reflect.Modifier.isPublic(m) && !java.lang.reflect.Modifier.isProtected(m) && !java.lang.reflect.Modifier.isPrivate(m)),
+    DEFAULT_ACCESS(m -> !java.lang.reflect.Modifier.isPublic(m)
+        && !java.lang.reflect.Modifier.isProtected(m)
+        && !java.lang.reflect.Modifier.isPrivate(m)
+    ),
     STATIC(java.lang.reflect.Modifier::isStatic),
     NON_STATIC(m -> !java.lang.reflect.Modifier.isStatic(m)),
     FINAL(java.lang.reflect.Modifier::isFinal),
@@ -34,5 +41,32 @@ public enum Modifier {
 
     public String keyword() {
         return name().toLowerCase();
+    }
+
+    /**
+     * Returns a list of all modifiers that are present in the given modifier.
+     *
+     * @param modifiers the modifiers
+     * @return the modifiers
+     */
+    public static Modifier[] fromInt(int modifiers) {
+        return Arrays.stream(values())
+            .filter(Predicate.not(CLASS::equals))
+            .filter(m -> m.is(modifiers)).toArray(Modifier[]::new);
+    }
+
+    /**
+     * Returns a list of all modifiers that are present in the given modifier. Negative modifiers like not_final are
+     * ignored.
+     *
+     * @param modifiers the modifiers
+     * @return the modifiers
+     */
+    public static Modifier[] fromIntPositive(int modifiers) {
+        return Arrays.stream(values())
+            .filter(Predicate.not(CLASS::equals))
+            .filter(m -> !m.name().startsWith("NON_"))
+            .filter(m -> m.is(modifiers))
+            .toArray(Modifier[]::new);
     }
 }

--- a/tutor/src/main/java/org/tudalgo/algoutils/tutor/general/stringify/basic/ReflectionStringifier.java
+++ b/tutor/src/main/java/org/tudalgo/algoutils/tutor/general/stringify/basic/ReflectionStringifier.java
@@ -44,7 +44,7 @@ public final class ReflectionStringifier implements Stringifier {
      * The object handlers. They are processed in the opposite order they were added. This means by adding a handler for
      * an existing matcher, the new handler will be processed first thus overriding the old handler.
      */
-    private final Map<Matcher<Object>, Function<Object, String>> objectHandlers = new HashMap<>();
+    private final Map<Matcher<Object>, Function<Object, String>> objectHandlers = new LinkedHashMap<>();
 
     /**
      * Registers an object handler for the given matcher.

--- a/tutor/src/main/java/org/tudalgo/algoutils/tutor/general/stringify/basic/ReflectionStringifier.java
+++ b/tutor/src/main/java/org/tudalgo/algoutils/tutor/general/stringify/basic/ReflectionStringifier.java
@@ -1,8 +1,12 @@
 package org.tudalgo.algoutils.tutor.general.stringify.basic;
 
+import com.google.common.collect.Streams;
 import org.tudalgo.algoutils.tutor.general.SpoonUtils;
+import org.tudalgo.algoutils.tutor.general.match.BasicReflectionMatchers;
 import org.tudalgo.algoutils.tutor.general.match.Matcher;
+import org.tudalgo.algoutils.tutor.general.reflections.BasicTypeLink;
 import org.tudalgo.algoutils.tutor.general.reflections.Link;
+import org.tudalgo.algoutils.tutor.general.reflections.TypeLink;
 import org.tudalgo.algoutils.tutor.general.stringify.Stringifier;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtNamedElement;
@@ -11,11 +15,11 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Objects;
+import java.util.*;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 import static java.lang.String.format;
 
@@ -24,10 +28,56 @@ import static java.lang.String.format;
  */
 public final class ReflectionStringifier implements Stringifier {
 
+    /**
+     * The singleton instance of this class.
+     */
     private static final ReflectionStringifier instance = new ReflectionStringifier();
 
     /**
-     * Returns an instance of this class
+     * Private constructor to prevent instantiation.
+     */
+    private ReflectionStringifier() {
+        registerDefaultTypehandlers();
+    }
+
+    /**
+     * The object handlers. They are processed in the opposite order they were added. This means by adding a handler for
+     * an existing matcher, the new handler will be processed first thus overriding the old handler.
+     */
+    private final Map<Matcher<Object>, Function<Object, String>> objectHandlers = new HashMap<>();
+
+    /**
+     * Registers an object handler for the given matcher.
+     *
+     * @param matcher the matcher to register the handler for
+     * @param handler the handler to register
+     */
+    public void registerObjectHandler(Matcher<Object> matcher, Function<Object, String> handler) {
+        objectHandlers.put(matcher, handler);
+    }
+
+    /**
+     * Registers a type handler for the given matcher.
+     *
+     * @param matcher the matcher to register the handler for
+     * @param handler the handler to register
+     */
+    public void registerTypeHandler(Matcher<TypeLink> matcher, Function<Object, String> handler) {
+        objectHandlers.put(Matcher.of(e -> e.getClass().isAssignableFrom(TypeLink.class)), handler);
+    }
+
+    /**
+     * Registers a type handler for the given class.
+     *
+     * @param clazz   the class to register the handler for
+     * @param handler the handler to register
+     */
+    public void registerTypeHandler(Class<?> clazz, Function<Object, String> handler) {
+        registerTypeHandler(BasicReflectionMatchers.sameType(clazz), handler);
+    }
+
+    /**
+     * Returns an instance of this class.
      *
      * @return the instance of this class
      */
@@ -37,63 +87,96 @@ public final class ReflectionStringifier implements Stringifier {
 
     @Override
     public String stringifyOrElseNull(Object object) {
-        if (object == null)
-            return null;
-        if (object instanceof String s) {
-            return s;
-        } else if (object instanceof boolean[]) {
-            return Arrays.toString((boolean[]) object);
-        } else if (object instanceof byte[]) {
-            return Arrays.toString((byte[]) object);
-        } else if (object instanceof char[]) {
-            return Arrays.toString((char[]) object);
-        } else if (object instanceof double[]) {
-            return Arrays.toString((double[]) object);
-        } else if (object instanceof float[]) {
-            return Arrays.toString((float[]) object);
-        } else if (object instanceof int[]) {
-            return Arrays.toString((int[]) object);
-        } else if (object instanceof long[]) {
-            return Arrays.toString((long[]) object);
-        } else if (object instanceof short[]) {
-            return Arrays.toString((short[]) object);
-        } else if (object instanceof Object[]) {
-            return Arrays.stream((Object[]) object)
-                .map(this::stringifyOrElseNull)
-                .collect(Collectors.joining(", ", "[", "]"));
-        } else if (object instanceof List<?> l) {
-            return l.stream().map(this::stringifyOrElseNull).collect(Collectors.joining(", ", "[", "]"));
-        } else if (object instanceof Matcher<?> m) {
-            return stringifyOrElseNull(m.object());
-        } else if (object instanceof Link l) {
-            return stringifyOrElseNull(l.reflection());
-        } else if (object instanceof Class<?> clazz && clazz.isAssignableFrom(CtElement.class)) {
-            var spoonName = SpoonUtils.getNameOfCtElement(clazz);
-            return spoonName != null ? spoonName : clazz.getSimpleName();
-        } else if (object instanceof Class<?> clazz) {
-            return clazz.getSimpleName();
-        } else if (object instanceof Field field) {
-            var clazzString = field.getDeclaringClass().getSimpleName();
-            var typeString = field.getType().getSimpleName();
-            var name = field.getName();
-            return format("%s#%s %s", clazzString, typeString, name);
-        } else if (object instanceof Method method) {
-            var clazzString = method.getDeclaringClass().getSimpleName();
-            var name = method.getName();
-            var parametersString = Stream.of(method.getParameters())
-                .map(parameter -> format("%s", parameter.getType().getSimpleName()))
-                .collect(Collectors.joining(", "));
-            return format("%s#%s(%s)", clazzString, name, parametersString);
-        } else if (object instanceof Parameter parameter) {
-            var typeString = parameter.getType().getSimpleName();
-            return format("%s", typeString);
-        } else if (object instanceof Constructor<?> c) {
-            return format("constructor of %s", c.getDeclaringClass().getSimpleName());
-        } else if (object instanceof CtNamedElement e) {
-            return e.getSimpleName();
-        } else if (object instanceof CtElement e) {
-            return SpoonUtils.getNameOfCtElement(e);
+        // iterate over all type handlers in reverse order
+        for (var entry : objectHandlers.entrySet()) {
+            var matcher = entry.getKey();
+            var handler = entry.getValue();
+            if (matcher.match(object).matched()) {
+                return handler.apply(object);
+            }
         }
         return Objects.toString(object);
+    }
+
+    private void registerDefaultTypehandlers() {
+        registerObjectHandler(Matcher.of(Objects::isNull), e -> null);
+        registerTypeHandler(
+            String.class, e -> (String) e
+        );
+        // register type handlers for arrays
+        registerObjectHandler(
+            Matcher.of(e -> e.getClass().isArray(), "Array"),
+            e -> Arrays.stream((Object[]) e)
+                .map(this::stringifyOrElseNull)
+                .toList()
+                .toString()
+        );
+        // register type handlers for Iterables
+        registerObjectHandler(
+            Matcher.of(e -> e instanceof Iterable<?>, "Iterable"),
+            e -> StreamSupport.stream(((Iterable<?>) e).spliterator(), false)
+                .map(this::stringifyOrElseNull)
+                .toList()
+                .toString()
+        );
+        // register type handlers for Internal algoutils.tutor types
+        registerTypeHandler(
+            Matcher.class, e -> stringifyOrElseNull(((Matcher<?>) e).characteristic())
+        );
+        registerTypeHandler(
+            Link.class, e -> stringifyOrElseNull(((Link) e).reflection())
+        );
+        registerTypeHandler(
+            Class.class, e -> stringifyOrElseNull(((Class<?>) e).getSimpleName())
+        );
+        registerObjectHandler(
+            Matcher.of(e -> e instanceof Class<?> clazz && clazz.isAssignableFrom(CtElement.class)),
+            e -> {
+                var spoonName = SpoonUtils.getNameOfCtElement((Class<?>) e);
+                return spoonName != null ? spoonName : ((Class<?>) e).getSimpleName();
+            }
+        );
+        registerTypeHandler(
+            Field.class, e -> {
+                var field = (Field) e;
+                var clazzString = field.getDeclaringClass().getSimpleName();
+                var typeString = field.getType().getSimpleName();
+                var name = field.getName();
+                return format("%s#%s %s", clazzString, typeString, name);
+            }
+        );
+        registerTypeHandler(
+            Method.class, e -> {
+                var method = (Method) e;
+                var clazzString = method.getDeclaringClass().getSimpleName();
+                var name = method.getName();
+                var parametersString = Stream.of(method.getParameters())
+                    .map(this::stringifyOrElseNull)
+                    .collect(Collectors.joining(", "));
+                return format("%s#%s(%s)", clazzString, name, parametersString);
+            }
+        );
+        registerTypeHandler(
+            Parameter.class, e -> {
+                var parameter = (Parameter) e;
+                var typeString = parameter.getType().getSimpleName();
+                return format("%s", typeString);
+            }
+        );
+        registerTypeHandler(
+            Constructor.class, e -> {
+                var constructor = (Constructor<?>) e;
+                return format("constructor of %s", constructor.getDeclaringClass().getSimpleName());
+            }
+        );
+        registerTypeHandler(
+            CtElement.class, e -> {
+                var ctElement = (CtElement) e;
+                return SpoonUtils.getNameOfCtElement(ctElement);
+            }
+        );
+        registerTypeHandler(
+            CtNamedElement.class, e -> ((CtNamedElement) e).getSimpleName()
+        );
     }
 }


### PR DESCRIPTION
This PRs primary focus is to provide the full functionality of the old reflect package with the new assertion api. So far this includes:
- [x] syntactic sugar (a lot)
- [x] checking if a method from an interface is implemented
- [x] verifying no blacklisted statements were used
- [x] improved error message handling (e.g. fixing cause not shown with Assertions2.call())
- [x] add missing documentation