### PR TITLE
Fix ReflectionStringifier for primitive arrays (#154)

### DIFF
--- a/tutor/src/main/java/org/tudalgo/algoutils/tutor/general/assertions/basic/BasicProperty.java
+++ b/tutor/src/main/java/org/tudalgo/algoutils/tutor/general/assertions/basic/BasicProperty.java
@@ -15,6 +15,22 @@ public record BasicProperty(
     Object value
 ) implements Property {
 
+    public BasicProperty {
+        // Test validity when creating so that a faulty property gets spotted early.
+        if(value.getClass().isArray()) {
+            // Get most inner array type
+            Class<?> elementType = value.getClass().getComponentType();
+            while(elementType.isArray()) {
+                elementType = elementType.getComponentType();
+            }
+            if(elementType.isPrimitive()) {
+                if(elementType != int.class && elementType != long.class && elementType != double.class)
+                    throw new IllegalArgumentException(
+                        "Context Property only supports arrays of types int, long, double, Object");
+            }
+        }
+    }
+
     /**
      * <p>Returns true iff the object is a property with the same key. </p>
      *

--- a/tutor/src/main/java/org/tudalgo/algoutils/tutor/general/stringify/basic/ReflectionStringifier.java
+++ b/tutor/src/main/java/org/tudalgo/algoutils/tutor/general/stringify/basic/ReflectionStringifier.java
@@ -106,7 +106,7 @@ public final class ReflectionStringifier implements Stringifier {
         // register type handlers for arrays
         registerObjectHandler(
             Matcher.of(e -> e.getClass().isArray(), "Array"),
-            e -> Arrays.stream((Object[]) e)
+            e -> getArrayStream(e)
                 .map(this::stringifyOrElseNull)
                 .toList()
                 .toString()
@@ -178,5 +178,28 @@ public final class ReflectionStringifier implements Stringifier {
         registerTypeHandler(
             CtNamedElement.class, e -> ((CtNamedElement) e).getSimpleName()
         );
+    }
+
+    /**
+     * Converts an Object of Type array to its corresponding Stream. Assumes the input to actually be an array.
+     * @param e the object to turn into a stream
+     * @return the corresponding stream
+     */
+    private Stream<?> getArrayStream(Object e) {
+        Class<?> componentType = e.getClass().getComponentType();
+        if(!componentType.isPrimitive()) {
+            return Arrays.stream((Object[]) e);
+        }
+        // Streams only support int, long and double everything else would need to be cast.
+        if(componentType == int.class) {
+            return Arrays.stream((int[])e).boxed();
+        } else if(componentType == long.class) {
+            return Arrays.stream((long[]) e).boxed();
+        } else if(componentType == double.class) {
+            return Arrays.stream((double[]) e).boxed();
+        }
+
+        throw new IllegalArgumentException(
+            "Can only cast Arrays of primitive types int, long and double. Got: " + componentType);
     }
 }

--- a/tutor/src/test/java/org/tudalgo/algoutils/tutor/general/stringifier/PrimitiveArraysTest.java
+++ b/tutor/src/test/java/org/tudalgo/algoutils/tutor/general/stringifier/PrimitiveArraysTest.java
@@ -1,0 +1,35 @@
+package org.tudalgo.algoutils.tutor.general.stringifier;
+
+import org.junit.jupiter.api.Test;
+import org.opentest4j.AssertionFailedError;
+import org.tudalgo.algoutils.tutor.general.assertions.Assertions2;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class PrimitiveArraysTest {
+
+    @Test
+    public void testStringifyDoubleArray() {
+        double[] testArray = new double[4];
+        for (int i = 0; i < testArray.length; i++) {
+            testArray[i] = i;
+        }
+        var context = Assertions2.contextBuilder().
+            add("array", testArray)
+            .build();
+        assertThrows(AssertionFailedError.class,
+            () -> Assertions2.assertEquals(0.5, 1.0, context, result -> "Failed"),
+            "Expected AssertionFailedError"
+        );
+    }
+
+    @Test
+    public void testCreationOfInvalidContext() {
+        byte[] testArray = new byte[0];
+        assertThrows(IllegalArgumentException.class,
+            () -> Assertions2.contextBuilder().add("faulty", testArray),
+            "Expected IllegalArgumentException"
+        );
+    }
+
+}


### PR DESCRIPTION
Fixes #154 

I also added a constructor to `BasicProperty` that checks whether the value of the property is a valid array we can stringify. Valid in this context meaning is of type: `int`, `long`, `double` and any non primitive type as these are the only types for which streams can be constructed. Additionally I also added tests to check that this behavior is consistent.